### PR TITLE
feat: implement minimize to tray functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2358,7 +2358,7 @@ dependencies = [
 
 [[package]]
 name = "ltk-manager"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/LeagueToolkit/ltk-manager"
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = ["protocol-asset", "devtools"] }
+tauri = { version = "2", features = ["protocol-asset", "devtools", "tray-icon"] }
 tauri-plugin-shell = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"

--- a/src-tauri/src/commands/shell.rs
+++ b/src-tauri/src/commands/shell.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
-use crate::error::{AppError, AppResult, IpcResult};
+use crate::error::{AppError, AppResult, IpcResult, MutexResultExt};
+use crate::state::SettingsState;
 
 /// Opens a file location in the system file explorer.
 #[tauri::command]
@@ -40,6 +41,35 @@ fn reveal_in_explorer_inner(path: &str) -> AppResult<()> {
             .arg(dir)
             .spawn()
             .map_err(|e| AppError::Other(format!("Failed to open file manager: {}", e)))?;
+    }
+
+    Ok(())
+}
+
+/// Minimizes the window to the system tray if the setting is enabled,
+/// otherwise performs a regular minimize.
+#[tauri::command]
+pub fn minimize_to_tray(
+    window: tauri::WebviewWindow,
+    state: tauri::State<SettingsState>,
+) -> IpcResult<()> {
+    minimize_to_tray_inner(window, &state).into()
+}
+
+fn minimize_to_tray_inner(
+    window: tauri::WebviewWindow,
+    state: &tauri::State<SettingsState>,
+) -> AppResult<()> {
+    let settings = state.0.lock().mutex_err()?;
+
+    if settings.minimize_to_tray {
+        window
+            .hide()
+            .map_err(|e| AppError::Other(format!("Failed to hide window: {}", e)))?;
+    } else {
+        window
+            .minimize()
+            .map_err(|e| AppError::Other(format!("Failed to minimize window: {}", e)))?;
     }
 
     Ok(())

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -3,6 +3,7 @@
     windows_subsystem = "windows"
 )]
 
+use tauri::tray::TrayIconBuilder;
 use tauri::Manager;
 use tracing_appender::{non_blocking::WorkerGuard, rolling};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
@@ -109,6 +110,22 @@ fn main() {
             app.manage(mod_library);
             app.manage(workshop);
 
+            // Set up system tray icon
+            let _tray = TrayIconBuilder::new()
+                .icon(app.default_window_icon().cloned().unwrap())
+                .tooltip("LTK Manager")
+                .on_tray_icon_event(|tray, event| {
+                    if let tauri::tray::TrayIconEvent::DoubleClick { .. } = event {
+                        let app = tray.app_handle();
+                        if let Some(window) = app.get_webview_window("main") {
+                            let _ = window.show();
+                            let _ = window.unminimize();
+                            let _ = window.set_focus();
+                        }
+                    }
+                })
+                .build(app)?;
+
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
@@ -146,6 +163,7 @@ fn main() {
             commands::rename_mod_profile,
             // Shell
             commands::reveal_in_explorer,
+            commands::minimize_to_tray,
             // Workshop
             commands::get_workshop_projects,
             commands::create_workshop_project,

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -107,7 +107,11 @@ pub struct AccentColor {
     pub custom_hue: Option<f32>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default, TS)]
+fn default_true() -> bool {
+    true
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
 #[ts(export)]
 #[serde(rename_all = "camelCase")]
 pub struct Settings {
@@ -133,9 +137,31 @@ pub struct Settings {
     /// Whether to patch TFT game files (Map22.wad.client). Default: false.
     #[serde(default)]
     pub patch_tft: bool,
+    /// Whether to minimize to system tray instead of taskbar. Default: true.
+    #[serde(default = "default_true")]
+    pub minimize_to_tray: bool,
     /// Whether the user has dismissed the cslol-manager migration banner.
     #[serde(default)]
     pub migration_dismissed: bool,
+}
+
+impl Default for Settings {
+    fn default() -> Self {
+        Self {
+            league_path: None,
+            mod_storage_path: None,
+            workshop_path: None,
+            first_run_complete: false,
+            theme: Theme::default(),
+            accent_color: AccentColor::default(),
+            backdrop_image: None,
+            backdrop_blur: None,
+            library_view_mode: None,
+            patch_tft: false,
+            minimize_to_tray: true,
+            migration_dismissed: false,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -151,6 +177,7 @@ mod tests {
         assert!(!settings.first_run_complete);
         assert_eq!(settings.theme, Theme::System);
         assert!(!settings.patch_tft);
+        assert!(settings.minimize_to_tray);
         assert!(!settings.migration_dismissed);
     }
 
@@ -170,6 +197,7 @@ mod tests {
             backdrop_blur: Some(40),
             library_view_mode: Some("list".to_string()),
             patch_tft: true,
+            minimize_to_tray: true,
             migration_dismissed: false,
         };
         let json = serde_json::to_string(&settings).unwrap();

--- a/src/components/Switch.tsx
+++ b/src/components/Switch.tsx
@@ -25,7 +25,7 @@ export const Switch = forwardRef<HTMLSpanElement, SwitchProps>(
       <BaseSwitch.Root
         ref={ref}
         className={twMerge(
-          "relative inline-flex rounded-full transition-colors",
+          "relative inline-flex shrink-0 rounded-full transition-colors",
           "bg-surface-700 data-[checked]:bg-brand-500",
           "data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50",
           trackClasses[size],

--- a/src/lib/bindings/Settings.ts
+++ b/src/lib/bindings/Settings.ts
@@ -35,6 +35,10 @@ export type Settings = {
    */
   patchTft: boolean;
   /**
+   * Whether to minimize to system tray instead of taskbar. Default: true.
+   */
+  minimizeToTray: boolean;
+  /**
    * Whether the user has dismissed the cslol-manager migration banner.
    */
   migrationDismissed: boolean;

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -96,6 +96,7 @@ export const api = {
 
   // Shell
   revealInExplorer: (path: string) => invokeResult<void>("reveal_in_explorer", { path }),
+  minimizeToTray: () => invokeResult<void>("minimize_to_tray"),
 
   // Workshop
   getWorkshopProjects: () => invokeResult<WorkshopProject[]>("get_workshop_projects"),

--- a/src/modules/settings/components/GeneralSection.tsx
+++ b/src/modules/settings/components/GeneralSection.tsx
@@ -4,6 +4,7 @@ import type { Settings } from "@/lib/tauri";
 import { MigrationSection, MigrationWizardDialog } from "@/modules/migration";
 
 import { LeaguePathSection } from "./LeaguePathSection";
+import { MinimizeToTraySection } from "./MinimizeToTraySection";
 import { ModStorageSection } from "./ModStorageSection";
 import { PatchingSection } from "./PatchingSection";
 import { WorkshopSection } from "./WorkshopSection";
@@ -20,6 +21,7 @@ export function GeneralSection({ settings, onSave }: GeneralSectionProps) {
     <div className="space-y-4">
       <LeaguePathSection settings={settings} onSave={onSave} />
       <PatchingSection settings={settings} onSave={onSave} />
+      <MinimizeToTraySection settings={settings} onSave={onSave} />
       <ModStorageSection settings={settings} onSave={onSave} />
       <WorkshopSection settings={settings} onSave={onSave} />
       <MigrationSection onImport={() => setMigrationOpen(true)} />

--- a/src/modules/settings/components/MinimizeToTraySection.tsx
+++ b/src/modules/settings/components/MinimizeToTraySection.tsx
@@ -1,0 +1,31 @@
+import { SectionCard, Switch } from "@/components";
+import type { Settings } from "@/lib/tauri";
+
+interface MinimizeToTraySectionProps {
+  settings: Settings;
+  onSave: (settings: Settings) => void;
+}
+
+export function MinimizeToTraySection({ settings, onSave }: MinimizeToTraySectionProps) {
+  return (
+    <SectionCard title="Minimize to Tray">
+      <div className="space-y-3">
+        <label className="flex items-center justify-between gap-4">
+          <div>
+            <span className="block text-sm font-medium text-surface-200">
+              Minimize to system tray
+            </span>
+            <span className="block text-sm text-surface-400">
+              When enabled, clicking the minimize button will hide the application to the system
+              tray instead of the taskbar. Double-click the tray icon to restore.
+            </span>
+          </div>
+          <Switch
+            checked={settings.minimizeToTray}
+            onCheckedChange={(checked) => onSave({ ...settings, minimizeToTray: checked })}
+          />
+        </label>
+      </div>
+    </SectionCard>
+  );
+}

--- a/src/modules/settings/components/index.ts
+++ b/src/modules/settings/components/index.ts
@@ -2,6 +2,7 @@ export { AboutSection } from "./AboutSection";
 export { AppearanceSection } from "./AppearanceSection";
 export { GeneralSection } from "./GeneralSection";
 export { LeaguePathSection } from "./LeaguePathSection";
+export { MinimizeToTraySection } from "./MinimizeToTraySection";
 export { ModStorageSection } from "./ModStorageSection";
 export { PatchingSection } from "./PatchingSection";
 export { WorkshopSection } from "./WorkshopSection";

--- a/src/modules/shell/components/TitleBar.tsx
+++ b/src/modules/shell/components/TitleBar.tsx
@@ -15,7 +15,7 @@ import {
 import { twMerge } from "tailwind-merge";
 
 import { IconButton, Tooltip } from "@/components";
-import type { AppInfo } from "@/lib/tauri";
+import { api, type AppInfo } from "@/lib/tauri";
 
 import { NotificationCenter } from "./NotificationCenter";
 
@@ -100,7 +100,9 @@ export function TitleBar({ title = "LTK Manager", appInfo }: TitleBarProps) {
     };
   }, [appWindow]);
 
-  const handleMinimize = () => appWindow.minimize();
+  const handleMinimize = () => {
+    api.minimizeToTray();
+  };
   const handleMaximize = () => appWindow.toggleMaximize();
   const handleClose = () => appWindow.close();
 

--- a/src/test/fixtures.ts
+++ b/src/test/fixtures.ts
@@ -12,6 +12,7 @@ export function createMockSettings(overrides?: Partial<Settings>): Settings {
     backdropBlur: null,
     libraryViewMode: "grid",
     patchTft: false,
+    minimizeToTray: true,
     migrationDismissed: false,
     ...overrides,
   };


### PR DESCRIPTION
Added minimize to tray functionality.

Since I noticed that you are creating a new program, I decided to add one feature that I think will be useful to many users, namely simple minimization of the application to the tray. Since many users will launch the application and it will simply hang there, I think it is unnecessary for it to be visible on the taskbar all the time (it can be particularly annoying when alt-tabbing), so I hope this feature will be useful.

Tested on Windows 10.
