### PR TITLE
feat: macOS patcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,5 +34,9 @@ src-tauri/src/lib/bindings/
 .claude/
 .mcp.json
 
+# cslol-dylib cmake build artifacts and generated dylib
+src-tauri/cslol-dylib/build-*/
+src-tauri/resources/libcslol.dylib
+
 # Windows
 nul

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -8,5 +8,101 @@ fn main() {
         std::fs::write(dist.join("index.html"), "").unwrap();
     }
 
+    #[cfg(target_os = "macos")]
+    build_cslol_dylib();
+
     tauri_build::build()
+}
+
+/// Build libcslol.dylib from the C++ sources in cslol-dylib/.
+///
+/// Produces a universal binary (arm64 + x86_64) and places it in
+/// src-tauri/resources/ where Tauri's bundler picks it up.
+#[cfg(target_os = "macos")]
+fn build_cslol_dylib() {
+    use std::path::PathBuf;
+    use std::process::Command;
+
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let cslol_dir = manifest_dir.join("cslol-dylib");
+    let resources_dir = manifest_dir.join("resources");
+    let output_path = resources_dir.join("libcslol.dylib");
+
+    // Track source files so Cargo knows when to rebuild.
+    let sources = [
+        "cslol-dylib/CMakeLists.txt",
+        "cslol-dylib/cslol_api.cpp",
+        "cslol-dylib/cslol-tools/lib/lol/common.cpp",
+        "cslol-dylib/cslol-tools/lib/lol/common.hpp",
+        "cslol-dylib/cslol-tools/lib/lol/error.cpp",
+        "cslol-dylib/cslol-tools/lib/lol/error.hpp",
+        "cslol-dylib/cslol-tools/lib/lol/fs.cpp",
+        "cslol-dylib/cslol-tools/lib/lol/fs.hpp",
+        "cslol-dylib/cslol-tools/lib/lol/patcher/patcher.hpp",
+        "cslol-dylib/cslol-tools/lib/lol/patcher/patcher_macos_arm64.cpp",
+        "cslol-dylib/cslol-tools/lib/lol/patcher/patcher_macos_amd64.cpp",
+        "cslol-dylib/cslol-tools/lib/lol/patcher/utility/macho.hpp",
+        "cslol-dylib/cslol-tools/lib/lol/patcher/utility/process.hpp",
+        "cslol-dylib/cslol-tools/lib/lol/patcher/utility/process_macos.cpp",
+        "cslol-dylib/cslol-tools/lib/lol/patcher/utility/delay.hpp",
+    ];
+    for src in &sources {
+        println!(
+            "cargo:rerun-if-changed={}",
+            manifest_dir.join(src).display()
+        );
+    }
+
+    std::fs::create_dir_all(&resources_dir).expect("Failed to create resources directory");
+
+    for arch in ["arm64", "x86_64"] {
+        let build_dir = cslol_dir.join(format!("build-{}", arch));
+
+        let status = Command::new("cmake")
+            .args([
+                "-B",
+                build_dir.to_str().unwrap(),
+                "-S",
+                cslol_dir.to_str().unwrap(),
+                "-DCMAKE_BUILD_TYPE=Release",
+                &format!("-DCMAKE_OSX_ARCHITECTURES={}", arch),
+            ])
+            .status()
+            .expect("cmake not found — install CMake to build the macOS patcher");
+        assert!(status.success(), "cmake configure failed for {}", arch);
+
+        let status = Command::new("cmake")
+            .args([
+                "--build",
+                build_dir.to_str().unwrap(),
+                "--config",
+                "Release",
+            ])
+            .status()
+            .expect("cmake build failed");
+        assert!(status.success(), "cmake build failed for {}", arch);
+    }
+
+    let status = Command::new("lipo")
+        .args([
+            "-create",
+            cslol_dir
+                .join("build-arm64/libcslol.dylib")
+                .to_str()
+                .unwrap(),
+            cslol_dir
+                .join("build-x86_64/libcslol.dylib")
+                .to_str()
+                .unwrap(),
+            "-output",
+            output_path.to_str().unwrap(),
+        ])
+        .status()
+        .expect("lipo failed");
+    assert!(status.success(), "lipo failed to create universal binary");
+
+    println!(
+        "cargo:warning=Built libcslol.dylib (universal) from source → {}",
+        output_path.display()
+    );
 }

--- a/src-tauri/cslol-dylib/CMakeLists.txt
+++ b/src-tauri/cslol-dylib/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.20)
+project(cslol VERSION 1.0.0 LANGUAGES CXX ASM)
+
+set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+set(LOL_LIB "${CMAKE_CURRENT_SOURCE_DIR}/cslol-tools/lib")
+
+add_library(cslol SHARED
+    cslol_api.cpp
+    ${LOL_LIB}/lol/common.cpp
+    ${LOL_LIB}/lol/error.cpp
+    ${LOL_LIB}/lol/fs.cpp
+    ${LOL_LIB}/lol/patcher/patcher_macos_arm64.cpp
+    ${LOL_LIB}/lol/patcher/patcher_macos_amd64.cpp
+    ${LOL_LIB}/lol/patcher/utility/process_macos.cpp
+)
+
+target_include_directories(cslol PRIVATE ${LOL_LIB})
+
+set_target_properties(cslol PROPERTIES
+    OUTPUT_NAME cslol
+    PREFIX lib
+    MACOSX_RPATH ON
+    BUILD_WITH_INSTALL_RPATH TRUE
+    INSTALL_RPATH "@loader_path"
+)

--- a/src-tauri/cslol-dylib/build.sh
+++ b/src-tauri/cslol-dylib/build.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RESOURCES_DIR="$SCRIPT_DIR/../resources"
+
+build_arch() {
+    local arch="$1"
+    cmake -B "$SCRIPT_DIR/build-$arch" -S "$SCRIPT_DIR" \
+        -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_ARCHITECTURES="$arch"
+    cmake --build "$SCRIPT_DIR/build-$arch" --config Release
+}
+
+build_arch arm64
+build_arch x86_64
+
+lipo -create \
+    "$SCRIPT_DIR/build-arm64/libcslol.dylib" \
+    "$SCRIPT_DIR/build-x86_64/libcslol.dylib" \
+    -output "$RESOURCES_DIR/libcslol.dylib"
+
+echo "Done: $RESOURCES_DIR/libcslol.dylib"
+file "$RESOURCES_DIR/libcslol.dylib"

--- a/src-tauri/cslol-dylib/cslol-tools/lib/lol/common.cpp
+++ b/src-tauri/cslol-dylib/cslol-tools/lib/lol/common.cpp
@@ -1,0 +1,14 @@
+#include <chrono>
+#include <lol/common.hpp>
+#include <thread>
+
+using namespace lol;
+
+#ifdef _WIN32
+extern "C" {
+extern void Sleep(unsigned ms);
+}
+void lol::sleep_ms(std::uint32_t ms) { Sleep(ms); }
+#else
+void lol::sleep_ms(std::uint32_t ms) { std::this_thread::sleep_for(std::chrono::milliseconds{ms}); }
+#endif

--- a/src-tauri/cslol-dylib/cslol-tools/lib/lol/common.hpp
+++ b/src-tauri/cslol-dylib/cslol-tools/lib/lol/common.hpp
@@ -1,0 +1,27 @@
+#pragma once
+// Modified for ltk-manager: replaced fmt/fmtlog with std::format (C++23).
+#include <format>
+#include <string>
+#include <string_view>
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <span>
+#include <utility>
+
+// Shim: route fmt::format → std::format so downstream code compiles unchanged.
+namespace fmt {
+    template <typename... Args>
+    inline std::string format(std::format_string<Args...> fstr, Args&&... args) {
+        return std::format(fstr, std::forward<Args>(args)...);
+    }
+}
+
+// No-op logging macros (fmtlog removed).
+#define logi(...) (void)0
+#define logd(...) (void)0
+
+namespace lol {
+    void sleep_ms(std::uint32_t ms);
+}

--- a/src-tauri/cslol-dylib/cslol-tools/lib/lol/error.cpp
+++ b/src-tauri/cslol-dylib/cslol-tools/lib/lol/error.cpp
@@ -1,0 +1,33 @@
+#include <exception>
+#include <lol/error.hpp>
+#include <lol/fs.hpp>
+
+using namespace lol;
+
+[[noreturn]] auto error::raise(std::string const& what) -> void { throw std::runtime_error(what); }
+
+auto error::stack() noexcept -> std::string& {
+    thread_local std::string instance = {};
+    return instance;
+}
+
+auto error::stack_trace() noexcept -> std::string {
+    auto& ss = stack();
+    std::string message = ss;
+    ss.clear();
+    return message;
+}
+
+auto error::path_sanitize(std::string str) noexcept -> std::string {
+    if (auto const& cd = fs::current_path_str(); !cd.empty()) {
+        for (auto i = str.find(cd); i != std::string::npos; i = str.find(cd)) {
+            str.replace(i, cd.size(), "./");
+        }
+    }
+    if (auto const& home = fs::home_path_str(); !home.empty()) {
+        for (auto i = str.find(home); i != std::string::npos; i = str.find(home)) {
+            str.replace(i, home.size(), "~/");
+        }
+    }
+    return str;
+}

--- a/src-tauri/cslol-dylib/cslol-tools/lib/lol/error.hpp
+++ b/src-tauri/cslol-dylib/cslol-tools/lib/lol/error.hpp
@@ -1,0 +1,75 @@
+#pragma once
+#include <lol/common.hpp>
+#include <exception>
+#include <stdexcept>
+#include <string>
+#include <system_error>
+
+#ifdef _MSC_VER
+#    define __PRETTY_FUNCTION__ __FUNCTION__
+#endif
+
+#define lol_paste_impl(x, y) x##y
+#define lol_paste(x, y) lol_paste_impl(x, y)
+
+#define lol_trace_func(...)                                                                \
+    ::lol::error::trace lol_paste(trace_, __LINE__) {                                      \
+        [&, func = __PRETTY_FUNCTION__] { ::lol::error::stack_push(func, ##__VA_ARGS__); } \
+    }
+
+#define lol_trace_var(fstr, name) fmt::format("{} = " fstr, #name, name)
+
+#define lol_throw_msg(fstr, ...) ::lol::error::raise(::fmt::format(fstr, ##__VA_ARGS__))
+
+#define lol_throw_if_msg(cond, fstr, ...)                                          \
+    do {                                                                           \
+        [[unlikely]] if (auto expr = cond) { lol_throw_msg(fstr, ##__VA_ARGS__); } \
+    } while (false)
+
+#define lol_throw_if(cond)                                                             \
+    do {                                                                               \
+        [[unlikely]] if (auto expr = cond) { lol_throw_msg("{} -> {}", #cond, expr); } \
+    } while (false)
+
+
+namespace lol::error {
+    [[noreturn]] extern auto raise(std::string const &what) -> void;
+
+    extern auto stack() noexcept -> std::string &;
+
+    extern auto stack_trace() noexcept -> std::string;
+
+    extern auto path_sanitize(std::string str) noexcept -> std::string;
+
+    template <typename... Args>
+    inline auto stack_push(std::string_view func, Args &&...args) noexcept -> void {
+        auto &stack_ref = stack();
+        stack_ref.append("\n  ").append(func.substr(0, func.find_first_of("("))).append(":");
+        (stack_ref.append("\n    ").append(std::forward<Args>(args)), ...);
+    }
+
+    template <typename Func>
+    struct trace : private Func {
+        inline trace(Func &&func) noexcept : Func(std::forward<Func>(func)) {}
+        inline ~trace() noexcept { [[unlikely]] if (std::uncaught_exceptions()) Func::operator()(); }
+    };
+
+    constexpr auto fix_func(std::string_view func) noexcept -> std::string_view {
+        return func.substr(0, func.find_first_of("("));
+    }
+}
+
+// std::formatter specializations (replacing fmt::formatter)
+template <>
+struct std::formatter<std::error_code> : std::formatter<std::string> {
+    auto format(std::error_code const &code, std::format_context &ctx) const {
+        return std::formatter<std::string>::format(lol::error::path_sanitize(code.message()), ctx);
+    }
+};
+
+template <>
+struct std::formatter<std::exception> : std::formatter<std::string> {
+    auto format(std::exception const &ex, std::format_context &ctx) const {
+        return std::formatter<std::string>::format(lol::error::path_sanitize(ex.what()), ctx);
+    }
+};

--- a/src-tauri/cslol-dylib/cslol-tools/lib/lol/fs.cpp
+++ b/src-tauri/cslol-dylib/cslol-tools/lib/lol/fs.cpp
@@ -1,0 +1,59 @@
+#include <stdlib.h>
+
+#include <lol/error.hpp>
+#include <lol/fs.hpp>
+
+using namespace lol;
+
+auto fs::home_path_str() noexcept -> std::string const& {
+    static std::string const instance = []() -> std::string {
+        auto result = std::string{};
+#ifdef _WIN32
+        auto homedrive = _wgetenv(L"HOMEDRIVE");
+        auto homepath = _wgetenv(L"HOMEPATH");
+        if (homedrive && homepath) result = (fs::path(homedrive) / homepath).generic_string();
+#else
+        auto home = getenv("HOME");
+        if (home) result = fs::path(home).generic_string();
+#endif
+        if (!result.empty() && !result.ends_with('/')) result.push_back('/');
+        // std::transform(result.begin(), result.end(), result.begin(), ::tolower);
+        return std::string(result.begin(), result.end());
+    }();
+    return instance;
+}
+
+auto fs::current_path_str() noexcept -> std::string const& {
+    static std::string const instance = []() -> std::string {
+        auto result = std::string{};
+        auto errc = std::error_code{};
+        result = fs::current_path().generic_string();
+        if (!result.empty() && !result.ends_with('/')) result.push_back('/');
+        // std::transform(result.begin(), result.end(), result.begin(), ::tolower);
+        return std::string(result.begin(), result.end());
+        ;
+    }();
+    return instance;
+}
+
+fs::tmp_dir::tmp_dir(fs::path path) {
+    lol_trace_func(lol_trace_var("{}", path));
+    if (fs::exists(path)) {
+        fs::remove_all(path);
+    }
+    fs::create_directories(path);
+    this->path = std::move(path);
+}
+
+fs::tmp_dir::~tmp_dir() noexcept {
+    if (!path.empty()) {
+        std::error_code ec = {};
+        fs::remove_all(path, ec);
+    }
+}
+
+auto fs::tmp_dir::move(fs::path const& dst) -> void {
+    lol_trace_func(lol_trace_var("{}", path), lol_trace_var("{}", dst));
+    fs::rename(this->path, dst);
+    this->path.clear();
+}

--- a/src-tauri/cslol-dylib/cslol-tools/lib/lol/fs.hpp
+++ b/src-tauri/cslol-dylib/cslol-tools/lib/lol/fs.hpp
@@ -1,0 +1,41 @@
+#pragma once
+#include <filesystem>
+#include <lol/common.hpp>
+#include <string>
+
+namespace lol::fs {
+    using namespace std::filesystem;
+
+    using names = fs::path;
+
+    extern auto home_path_str() noexcept -> std::string const &;
+
+    extern auto current_path_str() noexcept -> std::string const &;
+
+    struct tmp_dir {
+        tmp_dir(fs::path path);
+        ~tmp_dir() noexcept;
+
+        tmp_dir(tmp_dir const &) = delete;
+        tmp_dir(tmp_dir &&) = delete;
+        tmp_dir &operator=(tmp_dir const &) = delete;
+        tmp_dir &operator=(tmp_dir &&) = delete;
+
+        auto move(fs::path const &dst) -> void;
+
+        fs::path path;
+    };
+}
+
+template <>
+struct std::formatter<lol::fs::path> : std::formatter<std::string> {
+    auto format(lol::fs::path const &path, std::format_context &ctx) const {
+        auto result = path.generic_string();
+        if (auto const &cd = lol::fs::current_path_str(); !cd.empty() && result.starts_with(cd)) {
+            result.replace(0, cd.size(), "./");
+        } else if (auto const &home = lol::fs::home_path_str(); !home.empty() && result.starts_with(home)) {
+            result.replace(0, home.size(), "~/");
+        }
+        return std::formatter<std::string>::format(result, ctx);
+    }
+};

--- a/src-tauri/cslol-dylib/cslol-tools/lib/lol/patcher/patcher.hpp
+++ b/src-tauri/cslol-dylib/cslol-tools/lib/lol/patcher/patcher.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <functional>
+#include <lol/common.hpp>
+#include <lol/fs.hpp>
+
+namespace lol::patcher {
+    enum Message {
+        M_WAIT_START,
+        M_FOUND,
+        M_WAIT_INIT,
+        M_SCAN,
+        M_NEED_SAVE,
+        M_WAIT_PATCHABLE,
+        M_PATCH,
+        M_WAIT_EXIT,
+        M_DONE,
+        M_COUNT_OF,
+    };
+
+    static constexpr const char* const STATUS_MSG[Message::M_COUNT_OF] = {
+        "Waiting for league match to start",
+        "Found League",
+        "Wait initialized",
+        "Scanning",
+        "Saving",
+        "Wait patchable",
+        "Patching",
+        "Waiting for exit",
+        "League exited",
+    };
+
+    extern auto run(std::function<void(Message, char const*)> update,
+                    fs::path const& profile_path,
+                    fs::path const& config_path,
+                    fs::path const& game_path,
+                    fs::names const& opts) -> void;
+
+    /// Single-shot patch: open process by PID, scan, and patch.
+    /// Used by the C API wrapper (cslol_hook).
+    extern auto patch_process(std::uint32_t pid, fs::path const& profile_path) -> void;
+
+    struct PatcherTimeout : std::runtime_error {
+        using std::runtime_error::runtime_error;
+    };
+
+    struct PatcherAborted : std::runtime_error {
+        PatcherAborted() : std::runtime_error("Aborted as expected") {}
+    };
+}

--- a/src-tauri/cslol-dylib/cslol-tools/lib/lol/patcher/patcher_macos_amd64.cpp
+++ b/src-tauri/cslol-dylib/cslol-tools/lib/lol/patcher/patcher_macos_amd64.cpp
@@ -1,0 +1,327 @@
+#if defined(__APPLE__) && (defined(__x86_64__) || defined(__amd64__))
+#    include <algorithm>
+#    include <chrono>
+#    include <cstdio>
+#    include <cstring>
+#    include <functional>
+#    include <thread>
+
+#    include "utility/delay.hpp"
+#    include "utility/macho.hpp"
+#    include "utility/process.hpp"
+
+// do not reorder
+#    include <lol/error.hpp>
+#    include <lol/patcher/patcher.hpp>
+
+using namespace lol;
+using namespace lol::patcher;
+using namespace std::chrono_literals;
+
+// Compact payload for AMD64 — fits inside wad_verify's 184 bytes.
+// Same approach as ARM64: wad_verify bypass + fopen hook + data in one blob.
+// Import stub uses direct E9 JMP (no indirect pointer needed).
+//
+// The overlay path is written directly into the target process's __DATA segment
+// gap (unused padding between the last section and the segment boundary).
+// No symlinks, no new memory allocations.
+
+__asm__(R"(
+.text
+
+.global _payload_blob_beg_amd64
+.global _payload_blob_end_amd64
+
+_payload_blob_beg_amd64:
+
+// --- wad_verify bypass (6 bytes at offset 0) ---
+    .byte 0xB8, 0x01, 0x00, 0x00, 0x00     // mov eax, 1
+    .byte 0xC3                              // ret
+
+// --- fopen hook (at offset 6, jumped to by patched import stub) ---
+
+    // Early bailout — tail-call original fopen for non-matching calls
+    test    %rdi, %rdi
+    jz      Lamd64_passthru
+    cmpw    $0x6272, (%rsi)                 // "rb" as 16-bit
+    jne     Lamd64_passthru
+    cmpb    $0, 2(%rsi)
+    jne     Lamd64_passthru
+
+    // Matching call — full prologue
+    push    %rbp
+    mov     %rsp, %rbp
+    push    %r12
+    push    %r13
+    sub     $0x100, %rsp
+    mov     %rdi, %r12
+    mov     %rsi, %r13
+
+    // strlen + suffix check via repnz scasb
+    xor     %ecx, %ecx
+    mov     $0x80, %cl
+    xor     %al, %al
+    repnz   scasb
+    jnz     Lamd64_original
+    mov     -8(%rdi), %rax
+    movabs  $0x00746E65696C632E, %rcx       // ".client\0"
+    cmp     %rcx, %rax
+    jne     Lamd64_original
+
+    // Build prefix + filename on stack
+    mov     %rsp, %rdi
+    mov     Lamd64_prefix_ptr(%rip), %rsi
+Lamd64_pfx:
+    lodsb
+    stosb
+    test    %al, %al
+    jne     Lamd64_pfx
+    dec     %rdi
+    mov     %r12, %rsi
+Lamd64_fn:
+    lodsb
+    stosb
+    test    %al, %al
+    jne     Lamd64_fn
+
+    // Try modded path first
+    mov     %rsp, %rdi
+    mov     %r13, %rsi
+    mov     Lamd64_fopen_org(%rip), %rax
+    call    *(%rax)
+    test    %rax, %rax
+    jne     Lamd64_return
+
+Lamd64_original:
+    mov     %r12, %rdi
+    mov     %r13, %rsi
+    mov     Lamd64_fopen_org(%rip), %rax
+    call    *(%rax)
+
+Lamd64_return:
+    add     $0x100, %rsp
+    pop     %r13
+    pop     %r12
+    pop     %rbp
+    ret
+
+Lamd64_passthru:
+    mov     Lamd64_fopen_org(%rip), %rax
+    jmp     *(%rax)
+
+// --- data ---
+Lamd64_fopen_org:
+    .quad   0xDEAD1234DEAD5678
+
+Lamd64_prefix_ptr:
+    .quad   0xDEAD0000DEAD0000
+
+_payload_blob_end_amd64:
+)");
+
+extern "C" {
+    extern unsigned char payload_blob_beg_amd64[];
+    extern unsigned char payload_blob_end_amd64[];
+}
+
+static constexpr size_t WAD_VERIFY_SIZE_AMD64 = 184;
+static constexpr size_t HOOK_OFFSET = 6;
+static constexpr size_t PATH_BUFFER_SIZE = 256;
+static constexpr uint64_t PREFIX_PLACEHOLDER = 0xDEAD0000DEAD0000;
+
+// Import stub: E9 <rel32> + NOP (direct near jump, 6 bytes to match original stub size)
+struct Payload_import_stub {
+    uint8_t stub[6] = {};
+
+    static Payload_import_stub create(uint64_t from, uint64_t to) {
+        const int64_t offset = (int64_t)to - (int64_t)(from + 5);  // E9 is 5 bytes, RIP points past it
+        if (offset < std::numeric_limits<int32_t>::min() || offset > std::numeric_limits<int32_t>::max()) {
+            throw std::runtime_error("Import stub offset too big");
+        }
+        Payload_import_stub result{};
+        result.stub[0] = 0xE9;  // JMP rel32
+        uint32_t rel = static_cast<uint32_t>(offset);
+        memcpy(&result.stub[1], &rel, 4);
+        result.stub[5] = 0x90;  // NOP padding
+        return result;
+    }
+};
+
+static PtrStorage find_wad_verify(const uint8_t* text_beg, const uint8_t* text_end, uint64_t text_addr) {
+    uint8_t const PATTERN[] = {
+        0xB9, 0x26, 0x01, 0x00, 0x00, 0x41, 0xB8, 0x00, 0x01, 0x00, 0x00, 0x4C, 0x89, 0xF6, 0xE8
+    };
+    const auto i = std::search(text_beg, text_end, std::begin(PATTERN), std::end(PATTERN));
+    if ((text_end - i) < (int64_t)(sizeof(PATTERN) + 4)) return 0;
+
+    const uint8_t* text_disp = i + sizeof(PATTERN);
+    const int32_t disp = (int32_t)((uint32_t)text_disp[0] | ((uint32_t)text_disp[1] << 8) |
+                                   ((uint32_t)text_disp[2] << 16) | ((uint32_t)text_disp[3] << 24));
+    const uint64_t call_offset = text_addr + (text_disp + 4) - text_beg;
+    return call_offset + (uint64_t)disp;
+}
+
+struct Context {
+    std::uint64_t off_wad_verify = {};
+    std::uint64_t off_fopen_ptr = {};
+    std::uint64_t off_fopen_stub = {};
+    std::uint64_t off_data_gap = {};
+    std::size_t data_gap_size = {};
+
+    auto scan(Process const& process) -> void {
+        auto data = process.Dump();
+        auto macho = MachO{};
+        macho.parse_data_amd64((MachO::data_t)data.data(), data.size());
+
+        auto const [text_addr, text_data, text_size] = macho.find_section("__text");
+        if (!text_data) throw std::runtime_error("Failed to find __text section");
+
+        off_wad_verify = find_wad_verify(text_data, text_data + text_size, text_addr);
+        if (!off_wad_verify) throw std::runtime_error("Failed to find wad_verify call");
+
+        if (!(off_fopen_ptr = macho.find_import_ptr("_fopen")))
+            throw std::runtime_error("Failed to find fopen org");
+        if (!(off_fopen_stub = macho.find_stub_refs(off_fopen_ptr)))
+            throw std::runtime_error("Failed to find fopen stub");
+
+        auto const [gap_addr, gap_size] = macho.find_data_gap();
+        if (!gap_addr || gap_size < PATH_BUFFER_SIZE)
+            throw std::runtime_error("Failed to find __DATA gap for overlay path");
+        off_data_gap = gap_addr;
+        data_gap_size = gap_size;
+    }
+
+    auto check_already_patched(Process const& process) -> bool {
+        // amd64: MOV EAX, 1 (B8 01 00 00 00) + RET (C3)
+        uint8_t bypass_sig[] = {0xB8, 0x01, 0x00, 0x00, 0x00, 0xC3};
+        uint8_t existing[6] = {};
+        auto ptr = (void*)(uintptr_t)process.Rebase(off_wad_verify);
+        return process.TryReadMemory(ptr, existing, 6)
+            && memcmp(existing, bypass_sig, 6) == 0;
+    }
+
+    auto patch(Process const& process, std::string const& prefix) -> void {
+        if (check_already_patched(process))
+            throw std::runtime_error("Process is already patched");
+
+        auto const blob_size = (size_t)(payload_blob_end_amd64 - payload_blob_beg_amd64);
+        if (blob_size > WAD_VERIFY_SIZE_AMD64) {
+            lol_throw_msg("Payload too big: {} bytes (max {})", blob_size, WAD_VERIFY_SIZE_AMD64);
+        }
+
+        struct PayloadRegion { uint8_t data[WAD_VERIFY_SIZE_AMD64]; };
+        auto const ptr_wad_verify = process.Rebase<PayloadRegion>(off_wad_verify);
+        auto const ptr_fopen_ptr = process.Rebase(off_fopen_ptr);
+        auto const ptr_fopen_stub = process.Rebase<Payload_import_stub>(off_fopen_stub);
+
+        // Write overlay path to the __DATA segment gap
+        struct PathBuffer { char data[PATH_BUFFER_SIZE]; };
+        auto const ptr_data_gap = process.Rebase<PathBuffer>(off_data_gap);
+        PathBuffer path_buf = {};
+        strncpy(path_buf.data, prefix.c_str(), sizeof(path_buf.data) - 1);
+        process.MarkWritable(ptr_data_gap);
+        process.Write(ptr_data_gap, path_buf);
+
+        // Build payload with placeholders resolved
+        PayloadRegion payload = {};
+        memcpy(payload.data, payload_blob_beg_amd64, blob_size);
+
+        // Resolve fopen GOT pointer
+        uint64_t const fopen_placeholder = 0xDEAD1234DEAD5678;
+        uint64_t const fopen_ptr_addr = (uint64_t)ptr_fopen_ptr;
+        for (size_t i = 0; i <= blob_size - 8; i++) {
+            uint64_t val;
+            memcpy(&val, payload.data + i, 8);
+            if (val == fopen_placeholder) {
+                memcpy(payload.data + i, &fopen_ptr_addr, 8);
+                break;
+            }
+        }
+
+        // Resolve overlay path pointer (address of __DATA gap in target process)
+        uint64_t const data_gap_addr = (uint64_t)ptr_data_gap;
+        for (size_t i = 0; i <= blob_size - 8; i++) {
+            uint64_t val;
+            memcpy(&val, payload.data + i, 8);
+            if (val == PREFIX_PLACEHOLDER) {
+                memcpy(payload.data + i, &data_gap_addr, 8);
+                break;
+            }
+        }
+
+        auto const hook_addr = (PtrStorage)ptr_wad_verify + HOOK_OFFSET;
+        auto payload_stub = Payload_import_stub::create((PtrStorage)ptr_fopen_stub, hook_addr);
+
+        process.MarkWritable(ptr_wad_verify);
+        process.Write(ptr_wad_verify, payload);
+        process.MarkExecutable(ptr_wad_verify);
+
+        process.MarkWritable(ptr_fopen_stub);
+        process.Write(ptr_fopen_stub, payload_stub);
+        process.MarkExecutable(ptr_fopen_stub);
+    }
+};
+
+auto patcher::run(std::function<void(Message, char const*)> update,
+                  fs::path const& profile_path,
+                  fs::path const& config_path,
+                  fs::path const& game_path,
+                  fs::names const& opts) -> void {
+    auto const blob_size = (size_t)(payload_blob_end_amd64 - payload_blob_beg_amd64);
+    logi("Payload size: {} bytes (max {})", blob_size, WAD_VERIFY_SIZE_AMD64);
+    if (blob_size > WAD_VERIFY_SIZE_AMD64) {
+        throw std::runtime_error("Payload too big for wad_verify!");
+    }
+
+    auto prefix = profile_path.string();
+    if (!prefix.empty() && prefix.back() != '/') prefix += '/';
+
+    (void)config_path;
+    (void)game_path;
+    (void)opts;
+
+    auto ctx = Context{};
+    for (;;) {
+        auto pid = Process::FindPid("/LeagueofLegends");
+        if (!pid) {
+            update(M_WAIT_START, "");
+            sleep_ms(10);
+            continue;
+        }
+
+        update(M_FOUND, "");
+        auto process = Process::Open(pid);
+
+        update(M_SCAN, "");
+        ctx.scan(process);
+
+        update(M_PATCH, "");
+        ctx.patch(process, prefix);
+
+        update(M_WAIT_EXIT, "");
+        run_until_or(
+            3h,
+            Intervals{5s, 10s, 15s},
+            [&] { return process.IsExited(); },
+            []() -> bool { throw PatcherTimeout(std::string("Timed out exit")); });
+
+        update(M_DONE, "");
+    }
+}
+
+auto patcher::patch_process(std::uint32_t pid, fs::path const& profile_path) -> void {
+    auto process = Process::Open(pid);
+
+    auto proc_path = process.Path().string();
+    if (proc_path.find("LeagueofLegends") == std::string::npos)
+        throw std::runtime_error("Target process is not League of Legends");
+
+    auto prefix = profile_path.string();
+    if (!prefix.empty() && prefix.back() != '/') prefix += '/';
+
+    auto ctx = Context{};
+    ctx.scan(process);
+    ctx.patch(process, prefix);
+}
+
+#endif

--- a/src-tauri/cslol-dylib/cslol-tools/lib/lol/patcher/patcher_macos_arm64.cpp
+++ b/src-tauri/cslol-dylib/cslol-tools/lib/lol/patcher/patcher_macos_arm64.cpp
@@ -1,0 +1,351 @@
+#if defined(__APPLE__) && (defined(__aarch64__) || defined(__arm64__))
+#    include <algorithm>
+#    include <chrono>
+#    include <cstdio>
+#    include <cstring>
+#    include <functional>
+#    include <thread>
+
+#    include "utility/delay.hpp"
+#    include "utility/macho.hpp"
+#    include "utility/process.hpp"
+
+// do not reorder
+#    include <lol/error.hpp>
+#    include <lol/patcher/patcher.hpp>
+
+using namespace lol;
+using namespace lol::patcher;
+using namespace std::chrono_literals;
+
+// Compact payload that fits inside wad_verify's 272 bytes:
+//   [0x00] MOV X0, #1; RET          — wad_verify bypass (8 bytes)
+//   [0x08] fopen hook code           — redirects .wad.client reads
+//   [data] fopen_org_ptr             — pointer to GOT slot (8 bytes)
+//   [data] prefix_ptr                — pointer to overlay path in __DATA gap (8 bytes)
+//
+// The overlay path is written directly into the target process's __DATA segment
+// gap (unused padding between the last section and the segment boundary).
+// No symlinks, no new memory allocations.
+
+__asm__(R"(
+.text
+
+.global _payload_blob_beg
+.global _payload_blob_end
+
+.set buffer_size, 0x200
+
+filename .req x19
+mode .req x20
+filename_len .req x21
+fopen_org .req x22
+
+_payload_blob_beg:
+
+// --- wad_verify bypass (8 bytes at offset 0) ---
+    mov     x0, #1
+    ret
+
+// --- fopen hook (at offset 8, jumped to by patched import stub) ---
+    stp     fp, lr, [sp, #-16]!
+    mov     fp, sp
+    stp     filename, mode, [sp, #-16]!
+    stp     filename_len, fopen_org, [sp, #-16]!
+    sub     sp, sp, #buffer_size
+
+    mov     filename, x0
+    mov     mode, x1
+
+    adr     fopen_org, Lfopen_org
+    ldr     fopen_org, [fopen_org]
+    ldr     fopen_org, [fopen_org]
+
+    cbz     filename, Loriginal
+    cbz     mode, Loriginal
+
+    ldrb    w2, [mode]
+    cmp     w2, #'r'
+    b.ne    Loriginal
+    ldrb    w2, [mode, #1]
+    cmp     w2, #'b'
+    b.ne    Loriginal
+    ldrb    w2, [mode, #2]
+    cbnz    w2, Loriginal
+
+    mov     filename_len, #0
+    mov     x0, filename
+Lstrlen_loop:
+    ldrb    w2, [x0], #1
+    cbz     w2, Lstrlen_done
+    add     filename_len, filename_len, #1
+    tbnz    filename_len, #7, Loriginal
+    b       Lstrlen_loop
+Lstrlen_done:
+
+    cmp     filename_len, #7
+    b.lt    Loriginal
+    add     x0, filename, filename_len
+    sub     x0, x0, #7
+    ldr     x2, [x0]
+    movz    x3, #0x632E, lsl #0
+    movk    x3, #0x696C, lsl #16
+    movk    x3, #0x6E65, lsl #32
+    movk    x3, #0x0074, lsl #48
+    cmp     x2, x3
+    b.ne    Loriginal
+
+    // Build prefix + filename on stack
+    mov     x0, sp
+    adr     x1, Lprefix_ptr
+    ldr     x1, [x1]
+Lprefix_loop:
+    ldrb    w2, [x1], #1
+    strb    w2, [x0], #1
+    cbnz    w2, Lprefix_loop
+
+    sub     x0, x0, #1
+    mov     x1, filename
+Lfilename_loop:
+    ldrb    w2, [x1], #1
+    strb    w2, [x0], #1
+    cbnz    w2, Lfilename_loop
+
+    // Try modded path first
+    mov     x0, sp
+    mov     x1, mode
+    blr     fopen_org
+    cbnz    x0, Lreturn
+
+Loriginal:
+    mov     x0, filename
+    mov     x1, mode
+    blr     fopen_org
+
+Lreturn:
+    add     sp, sp, #buffer_size
+    ldp     filename_len, fopen_org, [sp], #16
+    ldp     filename, mode, [sp], #16
+    ldp     fp, lr, [sp], #16
+    ret
+
+// --- data ---
+Lfopen_org:
+    .quad   0xDEAD1234DEAD5678
+
+Lprefix_ptr:
+    .quad   0xDEAD0000DEAD0000
+
+_payload_blob_end:
+)");
+
+extern "C" {
+    extern unsigned char payload_blob_beg[];
+    extern unsigned char payload_blob_end[];
+}
+
+static constexpr size_t WAD_VERIFY_SIZE = 272;
+static constexpr size_t HOOK_OFFSET = 8;
+static constexpr size_t PATH_BUFFER_SIZE = 256;
+static constexpr uint64_t PREFIX_PLACEHOLDER = 0xDEAD0000DEAD0000;
+
+struct Payload_import_stub {
+    uint32_t adrp;
+    uint32_t add;
+    uint32_t br;
+
+    static Payload_import_stub create(uint64_t from, uint64_t to) {
+        const int64_t page_diff = (int64_t)((to & ~0xFFF) - (from & ~0xFFF)) >> 12;
+        if (page_diff < -0x100000 || page_diff > 0xFFFFF) {
+            throw std::runtime_error("Import stub offset too big");
+        }
+        const uint32_t imm21 = page_diff & 0x1FFFFF;
+        const uint32_t immlo = (imm21 & 0x3) << 29;
+        const uint32_t immhi = ((imm21 >> 2) & 0x7FFFF) << 5;
+        return Payload_import_stub{
+            .adrp = (uint32_t)(0x90000010 | immhi | immlo),
+            .add = (uint32_t)(0x91000210 | ((to & 0xFFF) << 10)),
+            .br = (uint32_t)(0xD61F0200),
+        };
+    }
+};
+
+static PtrStorage find_wad_verify(const uint8_t* text_beg, const uint8_t* text_end, uint64_t text_addr) {
+    uint8_t const PATTERN[] = {0xC3, 0x24, 0x80, 0x52, 0x04, 0x20, 0x80, 0x52};
+    const auto i = std::search(text_beg, text_end, std::begin(PATTERN), std::end(PATTERN));
+    if ((text_end - i) < (int64_t)(sizeof(PATTERN) + 4)) return 0;
+
+    const uint8_t* text_bl = i + sizeof(PATTERN);
+    const uint32_t instr = *(uint32_t const*)text_bl;
+    const uint32_t opcode = instr & 0xFC000000;
+    if (opcode != 0x94000000 && opcode != 0x14000000) return 0;
+    const int32_t offset = (int32_t)(instr << 6) >> 6;
+    const uint64_t bl_offset = text_bl - text_beg;
+    const uint64_t bl_pc = text_addr + bl_offset;
+    return bl_pc + (int64_t)offset * 4;
+}
+
+struct Context {
+    std::uint64_t off_wad_verify = {};
+    std::uint64_t off_fopen_ptr = {};
+    std::uint64_t off_fopen_stub = {};
+    std::uint64_t off_data_gap = {};
+    std::size_t data_gap_size = {};
+
+    auto scan(Process const& process) -> void {
+        auto data = process.Dump();
+        auto macho = MachO{};
+        macho.parse_data_arm64((MachO::data_t)data.data(), data.size());
+
+        auto const [text_addr, text_data, text_size] = macho.find_section("__text");
+        if (!text_data) throw std::runtime_error("Failed to find __text section");
+
+        off_wad_verify = find_wad_verify(text_data, text_data + text_size, text_addr);
+        if (!off_wad_verify) throw std::runtime_error("Failed to find wad_verify call");
+
+        if (!(off_fopen_ptr = macho.find_import_ptr("_fopen")))
+            throw std::runtime_error("Failed to find fopen org");
+        if (!(off_fopen_stub = macho.find_stub_refs(off_fopen_ptr)))
+            throw std::runtime_error("Failed to find fopen stub");
+
+        auto const [gap_addr, gap_size] = macho.find_data_gap();
+        if (!gap_addr || gap_size < PATH_BUFFER_SIZE)
+            throw std::runtime_error("Failed to find __DATA gap for overlay path");
+        off_data_gap = gap_addr;
+        data_gap_size = gap_size;
+    }
+
+    auto check_already_patched(Process const& process) -> bool {
+        // arm64: MOV X0, #1 (0xD2800020) + RET (0xD65F03C0)
+        uint8_t bypass_sig[] = {0x20, 0x00, 0x80, 0xD2, 0xC0, 0x03, 0x5F, 0xD6};
+        uint8_t existing[8] = {};
+        auto ptr = (void*)(uintptr_t)process.Rebase(off_wad_verify);
+        return process.TryReadMemory(ptr, existing, 8)
+            && memcmp(existing, bypass_sig, 8) == 0;
+    }
+
+    auto patch(Process const& process, std::string const& prefix) -> void {
+        if (check_already_patched(process))
+            throw std::runtime_error("Process is already patched");
+
+        auto const blob_size = (size_t)(payload_blob_end - payload_blob_beg);
+        if (blob_size > WAD_VERIFY_SIZE) {
+            lol_throw_msg("Payload too big: {} bytes (max {})", blob_size, WAD_VERIFY_SIZE);
+        }
+
+        struct PayloadRegion { uint8_t data[WAD_VERIFY_SIZE]; };
+        auto const ptr_wad_verify = process.Rebase<PayloadRegion>(off_wad_verify);
+        auto const ptr_fopen_ptr = process.Rebase(off_fopen_ptr);
+        auto const ptr_fopen_stub = process.Rebase<Payload_import_stub>(off_fopen_stub);
+
+        // Write overlay path to the __DATA segment gap
+        struct PathBuffer { char data[PATH_BUFFER_SIZE]; };
+        auto const ptr_data_gap = process.Rebase<PathBuffer>(off_data_gap);
+        PathBuffer path_buf = {};
+        strncpy(path_buf.data, prefix.c_str(), sizeof(path_buf.data) - 1);
+        process.MarkWritable(ptr_data_gap);
+        process.Write(ptr_data_gap, path_buf);
+
+        // Build payload with placeholders resolved
+        PayloadRegion payload = {};
+        memcpy(payload.data, payload_blob_beg, blob_size);
+
+        // Resolve fopen GOT pointer
+        uint64_t const fopen_placeholder = 0xDEAD1234DEAD5678;
+        uint64_t const fopen_ptr_addr = (uint64_t)ptr_fopen_ptr;
+        for (size_t i = 0; i <= blob_size - 8; i++) {
+            uint64_t val;
+            memcpy(&val, payload.data + i, 8);
+            if (val == fopen_placeholder) {
+                memcpy(payload.data + i, &fopen_ptr_addr, 8);
+                break;
+            }
+        }
+
+        // Resolve overlay path pointer (address of __DATA gap in target process)
+        uint64_t const data_gap_addr = (uint64_t)ptr_data_gap;
+        for (size_t i = 0; i <= blob_size - 8; i++) {
+            uint64_t val;
+            memcpy(&val, payload.data + i, 8);
+            if (val == PREFIX_PLACEHOLDER) {
+                memcpy(payload.data + i, &data_gap_addr, 8);
+                break;
+            }
+        }
+
+        auto const hook_addr = (PtrStorage)ptr_wad_verify + HOOK_OFFSET;
+        auto payload_stub = Payload_import_stub::create((PtrStorage)ptr_fopen_stub, hook_addr);
+
+        process.MarkWritable(ptr_wad_verify);
+        process.Write(ptr_wad_verify, payload);
+        process.MarkExecutable(ptr_wad_verify);
+
+        process.MarkWritable(ptr_fopen_stub);
+        process.Write(ptr_fopen_stub, payload_stub);
+        process.MarkExecutable(ptr_fopen_stub);
+    }
+};
+
+auto patcher::run(std::function<void(Message, char const*)> update,
+                  fs::path const& profile_path,
+                  fs::path const& config_path,
+                  fs::path const& game_path,
+                  fs::names const& opts) -> void {
+    auto const blob_size = (size_t)(payload_blob_end - payload_blob_beg);
+    logi("Payload size: {} bytes (max {})", blob_size, WAD_VERIFY_SIZE);
+    if (blob_size > WAD_VERIFY_SIZE) {
+        throw std::runtime_error("Payload too big for wad_verify!");
+    }
+
+    auto prefix = profile_path.string();
+    if (!prefix.empty() && prefix.back() != '/') prefix += '/';
+
+    (void)config_path;
+    (void)game_path;
+    (void)opts;
+
+    auto ctx = Context{};
+    for (;;) {
+        auto pid = Process::FindPid("/LeagueofLegends");
+        if (!pid) {
+            update(M_WAIT_START, "");
+            sleep_ms(10);
+            continue;
+        }
+
+        update(M_FOUND, "");
+        auto process = Process::Open(pid);
+
+        update(M_SCAN, "");
+        ctx.scan(process);
+
+        update(M_PATCH, "");
+        ctx.patch(process, prefix);
+
+        update(M_WAIT_EXIT, "");
+        run_until_or(
+            3h,
+            Intervals{5s, 10s, 15s},
+            [&] { return process.IsExited(); },
+            []() -> bool { throw PatcherTimeout(std::string("Timed out exit")); });
+
+        update(M_DONE, "");
+    }
+}
+
+auto patcher::patch_process(std::uint32_t pid, fs::path const& profile_path) -> void {
+    auto process = Process::Open(pid);
+
+    auto proc_path = process.Path().string();
+    if (proc_path.find("LeagueofLegends") == std::string::npos)
+        throw std::runtime_error("Target process is not League of Legends");
+
+    auto prefix = profile_path.string();
+    if (!prefix.empty() && prefix.back() != '/') prefix += '/';
+
+    auto ctx = Context{};
+    ctx.scan(process);
+    ctx.patch(process, prefix);
+}
+
+#endif

--- a/src-tauri/cslol-dylib/cslol-tools/lib/lol/patcher/utility/delay.hpp
+++ b/src-tauri/cslol-dylib/cslol-tools/lib/lol/patcher/utility/delay.hpp
@@ -1,0 +1,42 @@
+#pragma once
+#include <array>
+#include <chrono>
+#include <cstdint>
+#include <stdexcept>
+
+#include "lol/common.hpp"
+
+namespace lol {
+    template <std::size_t S>
+    struct Intervals {
+        Intervals() = default;
+
+        template <typename... T>
+        Intervals(T... intervals)
+            : intervals{static_cast<std::int64_t>(
+                  std::chrono::duration_cast<std::chrono::milliseconds>(intervals).count())...} {}
+
+        std::array<std::int64_t, S> intervals{1};
+    };
+
+    template <typename... T>
+    Intervals(T...) -> Intervals<sizeof...(T)>;
+
+    Intervals() -> Intervals<1>;
+
+    template <typename D, std::size_t S, typename P, typename F>
+    inline auto run_until_or(D deadline, Intervals<S> intervals, P&& poll, F&& fail) {
+        auto total = static_cast<std::int64_t>(std::chrono::duration_cast<std::chrono::milliseconds>(deadline).count());
+        for (auto interval : intervals.intervals) {
+            auto slice = total / S;
+            while (slice > 0) {
+                if (auto result = poll()) {
+                    return result;
+                }
+                sleep_ms(interval);
+                slice -= interval;
+            }
+        }
+        return fail();
+    }
+}

--- a/src-tauri/cslol-dylib/cslol-tools/lib/lol/patcher/utility/macho.hpp
+++ b/src-tauri/cslol-dylib/cslol-tools/lib/lol/patcher/utility/macho.hpp
@@ -1,0 +1,503 @@
+#pragma once
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <tuple>
+#include <unordered_map>
+#include <vector>
+
+namespace lol {
+    struct MachO {
+        using data_t = unsigned char const*;
+
+        struct Header {
+            std::uint32_t magic;
+            std::uint32_t cputype;
+            std::uint32_t cpusubtype;
+            std::uint32_t filetype;
+            std::uint32_t ncmds;
+            std::uint32_t sizeofcmds;
+            std::uint32_t flags;
+            std::uint32_t reserved;
+        };
+
+        struct Command {
+            std::uint32_t cmd;
+            std::uint32_t cmdsize;
+        };
+
+        struct Segment {
+            char segname[16];
+            std::uint64_t vmaddr;
+            std::uint64_t vmsize;
+            std::uint64_t fileoff;
+            std::uint64_t filesize;
+            std::int32_t maxprot;
+            std::int32_t initprot;
+            std::uint32_t nsects;
+            std::uint32_t flags;
+        };
+
+        struct Section {
+            char sectname[16];
+            char segname[16];
+            std::uint64_t addr;
+            std::uint64_t size;
+            std::uint32_t offset;
+            std::uint32_t align;
+            std::uint32_t reloff;
+            std::uint32_t nreloc;
+            std::uint32_t flags;
+            std::uint32_t reserved1;
+            std::uint32_t reserved2;
+            std::uint32_t reserved3;
+        };
+
+        struct SegSec : Segment {
+            std::vector<Section> sections;
+        };
+
+        struct DyldInfo {
+            std::uint32_t rebase_off;
+            std::uint32_t rebase_size;
+            std::uint32_t bind_off;
+            std::uint32_t bind_size;
+            std::uint32_t weak_bind_off;
+            std::uint32_t weak_bind_size;
+            std::uint32_t lazy_bind_off;
+            std::uint32_t lazy_bind_size;
+            std::uint32_t export_off;
+            std::uint32_t export_size;
+        };
+
+        struct Symtab {
+            std::uint32_t symoff;
+            std::uint32_t nsyms;
+            std::uint32_t stroff;
+            std::uint32_t strsize;
+        };
+
+        struct Export {
+            struct ReExport {
+                std::string name;
+                std::uint64_t ordinal;
+            };
+            struct StubAndResolver {
+                std::uint64_t stub_offset;
+                std::uint64_t resolver_offset;
+            };
+            std::optional<std::uint64_t> symbol_offset;
+            std::optional<ReExport> reexport;
+            std::optional<StubAndResolver> stub_and_resolver;
+        };
+
+        struct Symbol {
+            std::uint32_t n_strx;
+            std::uint8_t n_type;
+            std::uint8_t n_sect;
+            std::int16_t n_desc;
+            std::uint64_t n_value;
+        };
+
+        struct BindingLazy {
+            std::uint8_t binding_type = 0;
+            std::uint8_t sym_flags = 0;
+            std::uint8_t segment = 0;
+            std::int64_t lib_ord = 0;
+            std::uint64_t address = 0;
+        };
+
+        void parse_data_amd64(data_t data, size_t size) { parse_data(data, size, 0x1000007); }
+        void parse_data_arm64(data_t data, size_t size) { parse_data(data, size, 0x100000C); }
+        void parse_data(data_t data, size_t size, std::uint32_t cputype);
+
+        void parse_file_amd64(std::filesystem::path const& filename) { parse_file(filename, 0x1000007); }
+        void parse_file_arm64(std::filesystem::path const& filename) { parse_file(filename, 0x100000C); }
+        void parse_file(std::filesystem::path const& filename, std::uint32_t cputype);
+        std::uint64_t find_export(char const* func_name) const;
+        std::uint64_t find_import_ptr(char const* func_name) const;
+        std::uint64_t find_stub_refs(std::uint64_t address) const;
+        std::tuple<std::uint64_t, MachO::data_t, size_t> find_section(std::string_view name) const;
+
+        /// Find the unused gap at the end of the __DATA segment.
+        /// Returns (gap_vmaddr, gap_size) or (0, 0) if not found.
+        std::tuple<std::uint64_t, size_t> find_data_gap() const;
+
+    private:
+        struct Stream;
+        void read_impl(data_t data, size_t size);
+        void read_stubs(Stream const& org_stream, std::uint64_t address);
+        void read_exports(Stream const& org_stream);
+        void read_binding_lazy(Stream const& org_stream);
+
+        data_t data_ = {};
+        size_t size_ = {};
+        std::uint32_t cputype_ = {};
+        std::vector<SegSec> segments;
+        std::unordered_map<std::string, Export> exports;
+        std::unordered_map<std::string, BindingLazy> binding_lazy;
+        std::unordered_map<std::uint64_t, std::uint64_t> stub_refs;
+    };
+}
+
+/*************************************************************************************************/
+/* Implementation                                                                                */
+/*************************************************************************************************/
+
+namespace lol {
+    struct MachO::Stream {
+        data_t data_ = {};
+        size_t size_ = {};
+
+        inline bool empty() { return !size_; }
+
+        template <typename T>
+        inline T read_raw() {
+            if (size_ < sizeof(T)) {
+                throw std::runtime_error("Failed to read raw: no more data!");
+            }
+            unsigned char raw[sizeof(T)];
+            memcpy(raw, data_, sizeof(T));
+            T result;
+            memcpy(&result, raw, sizeof(T));
+            data_ = data_ + sizeof(T);
+            size_ -= sizeof(T);
+            return result;
+        }
+
+        inline uint32_t read_uint32_endian(bool big) {
+            auto const raw = read_raw<std::uint32_t>();
+            if (!big) return raw;
+            return raw >> 24 | ((raw & 0x00FF0000) >> 8) | ((raw & 0x0000FF00) << 8) | (raw << 24);
+        }
+
+        inline std::uint64_t read_uleb64() {
+            std::uint64_t result = 0;
+            for (int shift = 0; true; shift += 7) {
+                if (shift + 7 > 63) {
+                    throw std::runtime_error("Failed to read uleb64: value too big!");
+                }
+                auto const c = read_raw<std::uint8_t>();
+                result |= ((std::uint64_t)(c & 0x7f) << shift);
+                if (!(c & 0x80)) {
+                    break;
+                }
+            }
+            return result;
+        }
+
+        inline std::int64_t read_sleb64() {
+            std::int64_t result = 0;
+            for (int shift = 0; true; shift += 7) {
+                if (shift + 7 > 63) {
+                    throw std::runtime_error("Failed to read uleb64: value too big!");
+                }
+                auto const c = read_raw<std::uint8_t>();
+                result |= ((std::uint64_t)(c & 0x7f) << shift);
+                if (!(c & 0x80)) {
+                    result <<= 64 - (shift + 7);
+                    result >>= 64 - (shift + 7);
+                    break;
+                }
+            }
+            return result;
+        }
+
+        inline std::string read_zstring() {
+            auto result = std::string{};
+            while (auto const c = read_raw<char>()) {
+                result.push_back(c);
+            }
+            return result;
+        }
+
+        inline Stream copy(std::size_t offset = 0, std::size_t count = (std::size_t)-1) const {
+            if (offset > size_) {
+                throw std::runtime_error("Failed to seek: out of range!");
+            }
+            if (auto const remain_data = size_ - offset; count == (std::size_t)-1) {
+                count = remain_data;
+            } else {
+                if (remain_data < count) {
+                    throw std::runtime_error("Failed to seek: out of range!");
+                }
+            }
+            return Stream{data_ + offset, count};
+        }
+
+        inline void skip(std::size_t count) {
+            if (count > size_) {
+                throw std::runtime_error("Failed to skip: out of range!");
+            }
+            data_ += count;
+            size_ -= count;
+        }
+    };
+
+    inline void MachO::parse_data(data_t data, size_t size, std::uint32_t cputype) {
+        data_ = data;
+        size_ = size;
+        cputype_ = cputype;
+        segments.clear();
+        exports.clear();
+        binding_lazy.clear();
+        stub_refs.clear();
+
+        auto stream = Stream{data, size};
+        auto const magic = stream.read_raw<std::uint32_t>();
+        if (magic != 0xBEBAFECA && magic != 0xCAFEBABE) {
+            return read_impl(data, size);
+        }
+
+        auto const flip_endians = (magic != 0xCAFEBABE);
+        auto nfat_arch = stream.read_uint32_endian(flip_endians);
+        for (auto i = 0u; i != nfat_arch; ++i) {
+            auto const arch_cputype = stream.read_uint32_endian(flip_endians);
+            auto const arch_cpusubtype = stream.read_uint32_endian(flip_endians);
+            auto const arch_offset = stream.read_uint32_endian(flip_endians);
+            auto const arch_size = stream.read_uint32_endian(flip_endians);
+            auto const arch_align = stream.read_uint32_endian(flip_endians);
+
+            (void)arch_cpusubtype;  // ignore for now
+            (void)arch_align;       // ignore for now
+            if (arch_cputype == cputype) {
+                if (arch_offset + arch_size > size) {
+                    throw std::runtime_error("Invalid Mach-O slice: out of range!");
+                }
+                return read_impl(data + arch_offset, arch_size);
+            }
+        }
+        throw std::runtime_error("Failed to find Mach-O slice for the specified architecture!");
+    }
+
+    inline void MachO::read_impl(data_t data, size_t data_size) {
+        this->data_ = data;
+        this->size_ = data_size;
+        auto const file_stream = Stream{data, data_size};
+        auto stream = file_stream.copy();
+        auto const header = stream.read_raw<Header>();
+        for (auto count = header.ncmds; count; --count) {
+            auto cmd_stream = stream.copy();
+            auto const command = cmd_stream.read_raw<Command>();
+            if (command.cmd == 0x19) {
+                auto const segment = cmd_stream.read_raw<Segment>();
+                auto& segsec = this->segments.emplace_back(segment);
+                for (auto count = segment.nsects; count; --count) {
+                    auto const section = cmd_stream.read_raw<Section>();
+                    if (std::string_view{section.sectname} == "__stubs") {
+                        read_stubs(file_stream.copy(segment.fileoff + section.offset, section.size), section.addr);
+                    }
+                    segsec.sections.push_back(section);
+                }
+            }
+            if ((command.cmd & ~0x80000000u) == 0x22) {
+                auto const info = cmd_stream.read_raw<DyldInfo>();
+                read_exports(file_stream.copy(info.export_off, info.export_size));
+                read_binding_lazy(file_stream.copy(info.lazy_bind_off, info.lazy_bind_size));
+            }
+            stream.skip(command.cmdsize);
+        }
+    }
+
+    inline void MachO::parse_file(std::filesystem::path const& filename, std::uint32_t cputype) {
+        auto result = std::vector<unsigned char>{};
+        if (auto file = std::ifstream(filename, std::ios::binary)) {
+            auto beg = file.tellg();
+            file.seekg(std::ios::end);
+            auto end = file.tellg();
+            file.seekg(std::ios::beg);
+            result.resize((std::size_t)(end - beg));
+            file.read((char*)result.data(), end - beg);
+        }
+        parse_data(result.data(), result.size(), cputype);
+    }
+
+    inline void MachO::read_stubs(const Stream& org_stream, std::uint64_t address) {
+        auto stream = org_stream.copy();
+        while (!stream.empty()) {
+            if (cputype_ == 0x1000007) {
+                auto const opcode = stream.read_raw<std::uint16_t>();
+                if (opcode != 0x25FF) {
+                    // throw error here
+                }
+                auto const relative = stream.read_raw<std::int32_t>();
+                stub_refs[(address + 6) + relative] = address;
+                address += 6;
+            } else if (cputype_ == 0x100000C) {
+                auto const adrp = stream.read_raw<std::uint32_t>();
+                auto const ldr = stream.read_raw<std::uint32_t>();
+                auto const br = stream.read_raw<std::uint32_t>();
+                if ((adrp & 0x9F000000) != 0x90000000 || (ldr & 0xFF0003FF) != 0xF940021F ||
+                    (br & 0xFFFFFC1F) != 0xD61F0000) {
+                    // throw error here
+                }
+
+                // ADRP: Extract 21-bit signed page offset
+                auto const immlo = (adrp & 0x60000000) >> 29;                    // Bits 30:29
+                auto const immhi = (adrp & 0x00FFFFE0) >> 5;                     // Bits 23:5
+                auto const imm = (immhi << 2) | immlo;                           // Combine into 21-bit value
+                auto const sign = (imm & 0x100000) ? 0xFFFFFFFFFFE00000ULL : 0;  // Sign extend from bit 20
+                auto const relative = (sign | imm) << 12;                        // Convert page offset to byte offset
+                auto const page = (address + relative) & ~0xFFF;
+
+                // LDR: Extract scaled immediate offset
+                auto const page_offset = ((ldr >> 10) & 0xFFF) << 3;  // Bits 21:10, scaled by 8
+                auto const final_address = page + page_offset;
+                stub_refs[final_address] = address;
+                address += 12;
+            } else {
+                throw std::runtime_error("Unsupported CPU type for stubs!");
+            }
+        }
+    }
+
+    inline void MachO::read_exports(Stream const& org_stream) {
+        for (auto stack = std::vector<std::pair<std::string, std::size_t>>{{"", 0ull}}; !stack.empty();) {
+            auto const [sym_name, offset] = stack.back();
+            stack.pop_back();
+            auto stream = org_stream.copy(offset);
+            if (auto const info_len = stream.read_uleb64()) {
+                if (auto const flags = stream.read_uleb64(); flags & 0x08) {
+                    auto const ordinal = stream.read_uleb64();
+                    auto const name = stream.read_zstring();
+                    exports[sym_name] = Export{.reexport = Export::ReExport{
+                                                   .name = name,
+                                                   .ordinal = ordinal,
+                                               }};
+                } else if (flags & 0x10) {
+                    auto const stub_offset = stream.read_uleb64();
+                    auto const resolver_offset = stream.read_uleb64();
+                    exports[sym_name] = Export{.stub_and_resolver = Export::StubAndResolver{
+                                                   .stub_offset = stub_offset,
+                                                   .resolver_offset = resolver_offset,
+                                               }};
+                } else {
+                    auto const symbol_offset = stream.read_uleb64();
+                    exports[sym_name] = Export{.symbol_offset = symbol_offset};
+                }
+            }
+            for (auto child_count = (std::uint32_t)stream.read_raw<std::uint8_t>(); child_count; --child_count) {
+                auto const child_name = sym_name + stream.read_zstring();
+                auto const child_offset = stream.read_uleb64();
+                stack.emplace_back(child_name, child_offset);
+            }
+        }
+    }
+
+    inline void MachO::read_binding_lazy(Stream const& org_stream) {
+        std::string sym_name = "";
+        std::uint8_t binding_type = 0;
+        std::uint8_t segment = 0;
+        std::uint8_t sym_flags = 0;
+        std::int64_t lib_ord = 0;
+        std::uint64_t address = 0;
+        for (auto stream = org_stream; !stream.empty();) {
+            auto const raw_opcode = stream.read_raw<std::uint8_t>();
+            auto const opcode = raw_opcode & 0xF0;
+            auto const immediate = raw_opcode & 0x0F;
+            switch (opcode) {
+                case 0x00:
+                    sym_name = "";
+                    binding_type = 1;
+                    segment = 0;
+                    sym_flags = 0;
+                    lib_ord = 0;
+                    address = 0;
+                    break;
+                case 0x10:
+                    lib_ord = immediate;
+                    break;
+                case 0x20:
+                    lib_ord = stream.read_uleb64();
+                    break;
+                case 0x30:
+                    if (immediate) {
+                        lib_ord = immediate - std::int64_t{16};
+                    } else {
+                        lib_ord = 0;
+                    }
+                    break;
+                case 0x40:
+                    sym_name = stream.read_zstring();
+                    sym_flags = immediate;
+                    break;
+                case 0x50:
+                    binding_type = immediate;
+                    break;
+                case 0x70:
+                    address = stream.read_uleb64();
+                    segment = immediate;
+                    break;
+                case 0x90:
+                    binding_lazy[sym_name] = MachO::BindingLazy{
+                        .binding_type = binding_type,
+                        .sym_flags = sym_flags,
+                        .segment = segment,
+                        .lib_ord = lib_ord,
+                        .address = address,
+                    };
+                    break;
+                default:
+                    throw std::runtime_error("Unknown symbol binding opcode");
+            }
+        }
+    }
+
+    inline std::uint64_t MachO::find_export(char const* func_name) const {
+        if (auto i = exports.find(func_name); i != exports.end()) {
+            if (i->second.symbol_offset) {
+                return segments.at(0).vmsize + *i->second.symbol_offset;
+            }
+        }
+        return {};
+    }
+
+    inline std::uint64_t MachO::find_import_ptr(char const* func_name) const {
+        if (auto i = binding_lazy.find(func_name); i != binding_lazy.end()) {
+            if (i->second.binding_type == 1) {
+                return segments.at(i->second.segment).vmaddr + i->second.address;
+            }
+        }
+        return {};
+    }
+
+    inline std::uint64_t MachO::find_stub_refs(std::uint64_t address) const {
+        if (auto i = stub_refs.find(address); i != stub_refs.end()) {
+            return i->second;
+        }
+        return {};
+    }
+
+    inline std::tuple<std::uint64_t, MachO::data_t, size_t> MachO::find_section(std::string_view name) const {
+        auto stream = Stream{data_, size_};
+        for (const auto& segment : this->segments) {
+            for (const auto& section : segment.sections) {
+                if (std::string_view{section.sectname} != name) {
+                    continue;
+                }
+                const auto [data, size] = stream.copy(segment.fileoff + section.offset, section.size);
+                return {section.addr, data, size};
+            }
+        }
+        return {};
+    }
+
+    inline std::tuple<std::uint64_t, size_t> MachO::find_data_gap() const {
+        for (const auto& seg : this->segments) {
+            if (std::string_view{seg.segname} != "__DATA") continue;
+            uint64_t seg_end = seg.vmaddr + seg.vmsize;
+            uint64_t last_end = seg.vmaddr;
+            for (const auto& sec : seg.sections) {
+                uint64_t sec_end = sec.addr + sec.size;
+                if (sec_end > last_end) last_end = sec_end;
+            }
+            return {last_end, (size_t)(seg_end - last_end)};
+        }
+        return {0, 0};
+    }
+}

--- a/src-tauri/cslol-dylib/cslol-tools/lib/lol/patcher/utility/process.hpp
+++ b/src-tauri/cslol-dylib/cslol-tools/lib/lol/patcher/utility/process.hpp
@@ -1,0 +1,138 @@
+#pragma once
+#include <lol/common.hpp>
+#include <lol/fs.hpp>
+#include <optional>
+
+namespace lol::patcher {
+    template <typename T>
+    struct Ptr;
+
+    template <typename T>
+    Ptr(T *) -> Ptr<T>;
+
+    using PtrStorage = uint64_t;
+
+    template <>
+    struct Ptr<void> {
+        PtrStorage storage = {};
+        inline Ptr() noexcept = default;
+        inline Ptr(Ptr const &) noexcept = default;
+        inline Ptr(Ptr &&) noexcept = default;
+        inline Ptr &operator=(Ptr const &) noexcept = default;
+        inline Ptr &operator=(Ptr &&) noexcept = default;
+        inline Ptr(uintptr_t value) noexcept : storage((PtrStorage)(value)) {}
+        explicit inline Ptr(void *value) noexcept : Ptr((uintptr_t)(value)) {}
+        explicit inline operator void *() const noexcept { return (void *)((uintptr_t)(storage)); }
+        explicit inline operator PtrStorage() const noexcept { return storage; }
+    };
+
+    template <typename T>
+    struct Ptr : Ptr<void> {
+        static_assert(!std::is_pointer_v<T>);
+        using Ptr<void>::Ptr;
+        using Ptr<void>::operator void *;
+        using Ptr<void>::operator PtrStorage;
+        inline Ptr(T *value) noexcept : Ptr((uintptr_t)(value)) {}
+        inline auto operator->() const noexcept { return (T *)((void *)(*this)); }
+    };
+
+    struct Process {
+    private:
+        void *handle_ = nullptr;
+        mutable PtrStorage base_ = {};
+        mutable std::filesystem::path path_ = {};
+        mutable uint32_t pid_ = {};
+
+        Process(void *handle, std::uint32_t pid) noexcept : handle_(handle), pid_(pid) {}
+
+    public:
+        Process() noexcept;
+
+        Process(Process const &) = delete;
+        Process &operator=(Process const &) = delete;
+
+        Process(Process &&other) noexcept;
+        Process &operator=(Process &&other) noexcept;
+
+        ~Process() noexcept;
+
+        explicit inline operator bool() const noexcept { return handle_; }
+
+        inline bool operator!() const noexcept { return !handle_; }
+
+        static auto Open(std::uint32_t pid) -> Process;
+
+        static auto FindPid(char const *name) -> std::uint32_t;
+
+        static auto FindPidWindow(char const *window) -> std::uint32_t;
+
+        auto Base() const -> PtrStorage;
+
+        auto TryBase() const noexcept -> std::optional<PtrStorage>;
+
+        auto Path() const -> fs::path;
+
+        auto Dump() const -> std::vector<char>;
+
+        auto WaitInitialized(uint32_t timeout = 1) const noexcept -> bool;
+
+        auto IsExited() const noexcept -> bool;
+
+        auto TryReadMemory(void *address, void *dest, size_t size) const noexcept -> bool;
+
+        auto ReadMemory(void *address, void *dest, size_t size) const -> void;
+
+        auto WriteMemory(void *address, void const *src, size_t size) const -> void;
+
+        auto MarkMemoryExecutable(void *address, size_t size) const -> void;
+
+        auto MarkMemoryWritable(void *address, size_t size) const -> void;
+
+        auto AllocateMemory(size_t size) const -> void *;
+
+        template <typename T>
+        inline auto TryRead(Ptr<T> address) const noexcept -> std::optional<T> {
+            auto value = T{};
+            if (!TryReadMemory(static_cast<void *>(address), &value, sizeof(value))) {
+                return std::nullopt;
+            }
+            return value;
+        }
+
+        template <typename T>
+        inline auto Read(Ptr<T> address) const -> T {
+            auto dest = T{};
+            ReadMemory(static_cast<void *>(address), &dest, sizeof(T));
+            return dest;
+        }
+
+        template <typename T>
+        inline auto Write(Ptr<T> address, T const &src) const -> void {
+            WriteMemory(static_cast<void *>(address), &src, sizeof(T));
+        }
+
+        template <typename T>
+        inline auto Allocate() const -> Ptr<T> {
+            return static_cast<Ptr<T>>(AllocateMemory(sizeof(T)));
+        }
+
+        template <typename T>
+        inline auto MarkWritable(Ptr<T> address) const -> void {
+            MarkMemoryWritable(static_cast<void *>(address), sizeof(T));
+        }
+
+        template <typename T>
+        inline auto MarkExecutable(Ptr<T> address) const -> void {
+            MarkMemoryExecutable(static_cast<void *>(address), sizeof(T));
+        }
+
+        inline auto Rebase(PtrStorage offset) const -> PtrStorage { return offset + Base(); }
+
+        inline auto Debase(PtrStorage offset) const -> PtrStorage { return offset - Base(); }
+
+        template <typename T>
+        inline auto Rebase(PtrStorage offset) const -> Ptr<T> {
+            return Ptr<T>{offset + Base()};
+        }
+    };
+}

--- a/src-tauri/cslol-dylib/cslol-tools/lib/lol/patcher/utility/process_macos.cpp
+++ b/src-tauri/cslol-dylib/cslol-tools/lib/lol/patcher/utility/process_macos.cpp
@@ -1,0 +1,204 @@
+#ifdef __APPLE__
+#    include <lol/error.hpp>
+#    include <vector>
+
+#    include "process.hpp"
+// do not reoder
+#    include <libproc.h>
+#    include <mach/mach.h>
+#    include <mach/mach_traps.h>
+#    include <mach/mach_vm.h>
+#    include <unistd.h>
+
+using namespace lol;
+using namespace lol::patcher;
+
+Process::Process() noexcept = default;
+
+Process::Process(Process&& other) noexcept {
+    std::swap(handle_, other.handle_);
+    std::swap(base_, other.base_);
+    std::swap(path_, other.path_);
+    std::swap(pid_, other.pid_);
+}
+
+Process& Process::operator=(Process&& other) noexcept {
+    if (this == &other) return *this;
+    std::swap(handle_, other.handle_);
+    std::swap(base_, other.base_);
+    std::swap(path_, other.path_);
+    std::swap(pid_, other.pid_);
+    return *this;
+}
+
+Process::~Process() noexcept {
+    if (handle_) {
+        mach_port_deallocate(mach_task_self(), (mach_port_t)(std::size_t)handle_);
+    }
+}
+
+auto Process::FindPid(char const* name) -> std::uint32_t {
+    if (name) {
+        pid_t pids[4096];
+        int bytes = proc_listpids(PROC_ALL_PIDS, 0, pids, sizeof(pids));
+        int n_proc = bytes / sizeof(pid_t);
+        char pathbuf[PROC_PIDPATHINFO_MAXSIZE] = {};
+        for (auto p = pids; p != pids + n_proc; p++) {
+            if (auto const ret = proc_pidpath(*p, pathbuf, sizeof(pathbuf)); ret > 0) {
+                if (std::string_view{pathbuf, static_cast<std::size_t>(ret)}.ends_with(name)) {
+                    return static_cast<std::uint32_t>(*p);
+                }
+            }
+        }
+    }
+    return 0;
+}
+
+auto Process::FindPidWindow(char const* window) -> std::uint32_t { return 0; }
+
+auto Process::Open(std::uint32_t pid) -> Process {
+    if (mach_port_t task = {}; !task_for_pid(mach_task_self(), pid, &task)) {
+        return Process((void*)(std::uintptr_t)task, pid);
+    }
+    lol_throw_msg("task_for_pid");
+}
+
+auto Process::Base() const -> PtrStorage {
+    if (!base_) {
+        vm_map_offset_t vmoffset = {};
+        vm_map_size_t vmsize = {};
+        uint32_t nesting_depth = 0;
+        struct vm_region_submap_info_64 vbr[16] = {};
+        mach_msg_type_number_t vbrcount = 16;
+        kern_return_t kr;
+        if (auto const err = mach_vm_region_recurse((mach_port_t)(uintptr_t)handle_,
+                                                    &vmoffset,
+                                                    &vmsize,
+                                                    &nesting_depth,
+                                                    (vm_region_recurse_info_t)&vbr,
+                                                    &vbrcount)) {
+            lol_throw_msg("mach_vm_region_recurse: {:#x}", (std::uint32_t)err);
+        }
+        base_ = vmoffset - 0x100000000;
+    }
+    return base_;
+}
+
+auto Process::TryBase() const noexcept -> std::optional<PtrStorage> {
+    if (!base_) {
+        vm_map_offset_t vmoffset = {};
+        vm_map_size_t vmsize = {};
+        uint32_t nesting_depth = 0;
+        struct vm_region_submap_info_64 vbr[16] = {};
+        mach_msg_type_number_t vbrcount = 16;
+        kern_return_t kr;
+        if (auto const err = mach_vm_region_recurse((mach_port_t)(uintptr_t)handle_,
+                                                    &vmoffset,
+                                                    &vmsize,
+                                                    &nesting_depth,
+                                                    (vm_region_recurse_info_t)&vbr,
+                                                    &vbrcount)) {
+            return std::nullopt;
+        }
+        base_ = vmoffset - 0x100000000;
+    }
+    return base_;
+}
+
+auto Process::Path() const -> fs::path {
+    lol_trace_func();
+    if (!path_.empty()) return path_;
+    char pathbuf[PROC_PIDPATHINFO_MAXSIZE] = {};
+    if (auto const ret = proc_pidpath(pid_, pathbuf, sizeof(pathbuf)); ret <= 0) {
+        lol_throw_msg("proc_pidpath(pid: {}): {:#x}", pid_, (std::uint32_t)ret);
+    } else {
+        path_ = std::string{pathbuf, pathbuf + ret};
+    }
+    return path_;
+}
+
+auto Process::Dump() const -> std::vector<char> {
+    std::vector<char> buffer = {};
+    auto const path = Path().generic_string();
+    if (auto const file = fopen(path.c_str(), "rb")) {
+        auto const size = std::filesystem::file_size(path);
+        buffer.resize(size);
+        fread(buffer.data(), buffer.size(), 1, file);
+        fclose(file);
+    } else {
+        lol_throw_msg("fopen(path: {}, \"rb\") failed", path.c_str());
+    }
+    return buffer;
+}
+
+auto Process::IsExited() const noexcept -> bool {
+    int p = 0;
+    pid_for_task((mach_port_t)(uintptr_t)handle_, &p);
+    return p < 0;
+}
+
+auto Process::WaitInitialized(uint32_t timeout) const noexcept -> bool { return true; }
+
+auto Process::TryReadMemory(void* address, void* dest, size_t size) const noexcept -> bool {
+    mach_msg_type_number_t orgdata_read = 0;
+    vm_offset_t offset = {};
+    if (auto const err =
+            mach_vm_read((mach_port_t)(uintptr_t)handle_, (mach_vm_address_t)address, size, &offset, &orgdata_read)) {
+        return false;
+    }
+    if (orgdata_read != size) {
+        return false;
+    }
+    memcpy(dest, (void*)offset, orgdata_read);
+    return true;
+}
+
+auto Process::ReadMemory(void* address, void* dest, size_t size) const -> void {
+    mach_msg_type_number_t got_size = 0;
+    vm_offset_t offset = {};
+    if (auto const err =
+            mach_vm_read((mach_port_t)(uintptr_t)handle_, (mach_vm_address_t)address, size, &offset, &got_size)) {
+        lol_throw_msg("mach_vm_read: {:#x}", (std::uint32_t)err);
+    }
+    if (got_size != size) {
+        lol_throw_msg("mach_vm_read: got {:#x}", got_size);
+    }
+    memcpy(dest, (void*)offset, got_size);
+}
+
+auto Process::WriteMemory(void* address, void const* src, std::size_t sizeBytes) const -> void {
+    if (auto const err =
+            mach_vm_write((mach_port_t)(uintptr_t)handle_, (mach_vm_address_t)address, (vm_offset_t)src, sizeBytes)) {
+        lol_throw_msg("mach_vm_write: {:#x}", (std::uint32_t)err);
+    }
+}
+
+auto Process::MarkMemoryWritable(void* address, std::size_t size) const -> void {
+    if (auto const err = mach_vm_protect((mach_port_t)(uintptr_t)handle_,
+                                         (mach_vm_address_t)address,
+                                         (mach_vm_size_t)size,
+                                         FALSE,
+                                         VM_PROT_READ | VM_PROT_WRITE | VM_PROT_COPY)) {
+        lol_throw_msg("mach_vm_protect: {:#x}", (std::uint32_t)err);
+    }
+}
+
+auto Process::MarkMemoryExecutable(void* address, std::size_t size) const -> void {
+    if (auto const err = mach_vm_protect((mach_port_t)(uintptr_t)handle_,
+                                         (mach_vm_address_t)address,
+                                         (mach_vm_size_t)size,
+                                         FALSE,
+                                         VM_PROT_READ | VM_PROT_EXECUTE)) {
+        lol_throw_msg("mach_vm_protect: {:#x}", (std::uint32_t)err);
+    }
+}
+
+auto Process::AllocateMemory(size_t size) const -> void* {
+    mach_vm_address_t address = {};
+    if (auto const err = mach_vm_allocate((vm_map_t)(uintptr_t)handle_, &address, size, VM_FLAGS_ANYWHERE)) {
+        lol_throw_msg("mach_vm_allocate: {:#x}", (std::uint32_t)err);
+    }
+    return (void*)address;
+}
+
+#endif

--- a/src-tauri/cslol-dylib/cslol_api.cpp
+++ b/src-tauri/cslol-dylib/cslol_api.cpp
@@ -1,0 +1,75 @@
+/// C API wrapper for the macOS patcher.
+/// Exposes the same symbols as cslol-dll.dll on Windows so the Rust side
+/// can load either library through libloading without platform branching.
+#ifdef __APPLE__
+
+#include <chrono>
+#include <cstdint>
+#include <string>
+#include <thread>
+#include <uchar.h>
+
+#include <lol/patcher/patcher.hpp>
+#include <lol/patcher/utility/process.hpp>
+
+static std::string g_prefix;
+static std::string g_last_error;
+
+static std::string utf16_to_utf8(const char16_t* s) {
+    std::string result;
+    while (*s) {
+        char16_t c = *s++;
+        if (c < 0x80) {
+            result += static_cast<char>(c);
+        } else if (c < 0x800) {
+            result += static_cast<char>(0xC0 | (c >> 6));
+            result += static_cast<char>(0x80 | (c & 0x3F));
+        } else {
+            result += static_cast<char>(0xE0 | (c >> 12));
+            result += static_cast<char>(0x80 | ((c >> 6) & 0x3F));
+            result += static_cast<char>(0x80 | (c & 0x3F));
+        }
+    }
+    return result;
+}
+
+static const char* set_error(std::string msg) {
+    g_last_error = std::move(msg);
+    return g_last_error.c_str();
+}
+
+extern "C" {
+
+const char* cslol_init() { return nullptr; }
+
+const char* cslol_set_config(const char16_t* prefix) {
+    g_prefix = utf16_to_utf8(prefix);
+    return nullptr;
+}
+
+const char* cslol_set_flags(uint64_t) { return nullptr; }
+const char* cslol_set_log_level(int) { return nullptr; }
+const char* cslol_set_log_file(const char16_t*) { return nullptr; }
+const char* cslol_log_pull() { return nullptr; }
+
+unsigned cslol_find() {
+    return lol::patcher::Process::FindPid("/LeagueofLegends");
+}
+
+void cslol_sleep(uint32_t ms) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(ms));
+}
+
+const char* cslol_hook(unsigned pid, unsigned, unsigned) {
+    try {
+        lol::patcher::patch_process(pid, g_prefix);
+        return nullptr;
+    } catch (std::exception const& e) {
+        return set_error(e.what());
+    } catch (...) {
+        return set_error("Unknown error in cslol_hook");
+    }
+}
+
+}  // extern "C"
+#endif  // __APPLE__

--- a/src-tauri/gen/schemas/macOS-schema.json
+++ b/src-tauri/gen/schemas/macOS-schema.json
@@ -1,0 +1,6452 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "CapabilityFile",
+  "description": "Capability formats accepted in a capability file.",
+  "anyOf": [
+    {
+      "description": "A single capability.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Capability"
+        }
+      ]
+    },
+    {
+      "description": "A list of capabilities.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Capability"
+      }
+    },
+    {
+      "description": "A list of capabilities.",
+      "type": "object",
+      "required": [
+        "capabilities"
+      ],
+      "properties": {
+        "capabilities": {
+          "description": "The list of capabilities.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Capability"
+          }
+        }
+      }
+    }
+  ],
+  "definitions": {
+    "Capability": {
+      "description": "A grouping and boundary mechanism developers can use to isolate access to the IPC layer.\n\nIt controls application windows' and webviews' fine grained access to the Tauri core, application, or plugin commands. If a webview or its window is not matching any capability then it has no access to the IPC layer at all.\n\nThis can be done to create groups of windows, based on their required system access, which can reduce impact of frontend vulnerabilities in less privileged windows. Windows can be added to a capability by exact name (e.g. `main-window`) or glob patterns like `*` or `admin-*`. A Window can have none, one, or multiple associated capabilities.\n\n## Example\n\n```json { \"identifier\": \"main-user-files-write\", \"description\": \"This capability allows the `main` window on macOS and Windows access to `filesystem` write related commands and `dialog` commands to enable programmatic access to files selected by the user.\", \"windows\": [ \"main\" ], \"permissions\": [ \"core:default\", \"dialog:open\", { \"identifier\": \"fs:allow-write-text-file\", \"allow\": [{ \"path\": \"$HOME/test.txt\" }] }, ], \"platforms\": [\"macOS\",\"windows\"] } ```",
+      "type": "object",
+      "required": [
+        "identifier",
+        "permissions"
+      ],
+      "properties": {
+        "identifier": {
+          "description": "Identifier of the capability.\n\n## Example\n\n`main-user-files-write`",
+          "type": "string"
+        },
+        "description": {
+          "description": "Description of what the capability is intended to allow on associated windows.\n\nIt should contain a description of what the grouped permissions should allow.\n\n## Example\n\nThis capability allows the `main` window access to `filesystem` write related commands and `dialog` commands to enable programmatic access to files selected by the user.",
+          "default": "",
+          "type": "string"
+        },
+        "remote": {
+          "description": "Configure remote URLs that can use the capability permissions.\n\nThis setting is optional and defaults to not being set, as our default use case is that the content is served from our local application.\n\n:::caution Make sure you understand the security implications of providing remote sources with local system access. :::\n\n## Example\n\n```json { \"urls\": [\"https://*.mydomain.dev\"] } ```",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/CapabilityRemote"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "local": {
+          "description": "Whether this capability is enabled for local app URLs or not. Defaults to `true`.",
+          "default": true,
+          "type": "boolean"
+        },
+        "windows": {
+          "description": "List of windows that are affected by this capability. Can be a glob pattern.\n\nIf a window label matches any of the patterns in this list, the capability will be enabled on all the webviews of that window, regardless of the value of [`Self::webviews`].\n\nOn multiwebview windows, prefer specifying [`Self::webviews`] and omitting [`Self::windows`] for a fine grained access control.\n\n## Example\n\n`[\"main\"]`",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "webviews": {
+          "description": "List of webviews that are affected by this capability. Can be a glob pattern.\n\nThe capability will be enabled on all the webviews whose label matches any of the patterns in this list, regardless of whether the webview's window label matches a pattern in [`Self::windows`].\n\n## Example\n\n`[\"sub-webview-one\", \"sub-webview-two\"]`",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "permissions": {
+          "description": "List of permissions attached to this capability.\n\nMust include the plugin name as prefix in the form of `${plugin-name}:${permission-name}`. For commands directly implemented in the application itself only `${permission-name}` is required.\n\n## Example\n\n```json [ \"core:default\", \"shell:allow-open\", \"dialog:open\", { \"identifier\": \"fs:allow-write-text-file\", \"allow\": [{ \"path\": \"$HOME/test.txt\" }] } ] ```",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PermissionEntry"
+          },
+          "uniqueItems": true
+        },
+        "platforms": {
+          "description": "Limit which target platforms this capability applies to.\n\nBy default all platforms are targeted.\n\n## Example\n\n`[\"macOS\",\"windows\"]`",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Target"
+          }
+        }
+      }
+    },
+    "CapabilityRemote": {
+      "description": "Configuration for remote URLs that are associated with the capability.",
+      "type": "object",
+      "required": [
+        "urls"
+      ],
+      "properties": {
+        "urls": {
+          "description": "Remote domains this capability refers to using the [URLPattern standard](https://urlpattern.spec.whatwg.org/).\n\n## Examples\n\n- \"https://*.mydomain.dev\": allows subdomains of mydomain.dev - \"https://mydomain.dev/api/*\": allows any subpath of mydomain.dev/api",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "PermissionEntry": {
+      "description": "An entry for a permission value in a [`Capability`] can be either a raw permission [`Identifier`] or an object that references a permission and extends its scope.",
+      "anyOf": [
+        {
+          "description": "Reference a permission or permission set by identifier.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Identifier"
+            }
+          ]
+        },
+        {
+          "description": "Reference a permission or permission set by identifier and extends its scope.",
+          "type": "object",
+          "allOf": [
+            {
+              "if": {
+                "properties": {
+                  "identifier": {
+                    "anyOf": [
+                      {
+                        "description": "This set of permissions describes the what kind of\nfile system access the `fs` plugin has enabled or denied by default.\n\n#### Granted Permissions\n\nThis default permission set enables read access to the\napplication specific directories (AppConfig, AppData, AppLocalData, AppCache,\nAppLog) and all files and sub directories created in it.\nThe location of these directories depends on the operating system,\nwhere the application is run.\n\nIn general these directories need to be manually created\nby the application at runtime, before accessing files or folders\nin it is possible.\n\nTherefore, it is also allowed to create all of these folders via\nthe `mkdir` command.\n\n#### Denied Permissions\n\nThis default permission set prevents access to critical components\nof the Tauri application by default.\nOn Windows the webview data folder access is denied.\n\n#### This default permission set includes:\n\n- `create-app-specific-dirs`\n- `read-app-specific-dirs-recursive`\n- `deny-default`",
+                        "type": "string",
+                        "const": "fs:default",
+                        "markdownDescription": "This set of permissions describes the what kind of\nfile system access the `fs` plugin has enabled or denied by default.\n\n#### Granted Permissions\n\nThis default permission set enables read access to the\napplication specific directories (AppConfig, AppData, AppLocalData, AppCache,\nAppLog) and all files and sub directories created in it.\nThe location of these directories depends on the operating system,\nwhere the application is run.\n\nIn general these directories need to be manually created\nby the application at runtime, before accessing files or folders\nin it is possible.\n\nTherefore, it is also allowed to create all of these folders via\nthe `mkdir` command.\n\n#### Denied Permissions\n\nThis default permission set prevents access to critical components\nof the Tauri application by default.\nOn Windows the webview data folder access is denied.\n\n#### This default permission set includes:\n\n- `create-app-specific-dirs`\n- `read-app-specific-dirs-recursive`\n- `deny-default`"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to metadata of the application folders, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-app-index`",
+                        "type": "string",
+                        "const": "fs:allow-app-meta",
+                        "markdownDescription": "This allows non-recursive read access to metadata of the application folders, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-app-index`"
+                      },
+                      {
+                        "description": "This allows full recursive read access to metadata of the application folders, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-app-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-app-meta-recursive",
+                        "markdownDescription": "This allows full recursive read access to metadata of the application folders, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-app-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to the application folders.\n#### This permission set includes:\n\n- `read-all`\n- `scope-app`",
+                        "type": "string",
+                        "const": "fs:allow-app-read",
+                        "markdownDescription": "This allows non-recursive read access to the application folders.\n#### This permission set includes:\n\n- `read-all`\n- `scope-app`"
+                      },
+                      {
+                        "description": "This allows full recursive read access to the complete application folders, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-app-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-app-read-recursive",
+                        "markdownDescription": "This allows full recursive read access to the complete application folders, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-app-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive write access to the application folders.\n#### This permission set includes:\n\n- `write-all`\n- `scope-app`",
+                        "type": "string",
+                        "const": "fs:allow-app-write",
+                        "markdownDescription": "This allows non-recursive write access to the application folders.\n#### This permission set includes:\n\n- `write-all`\n- `scope-app`"
+                      },
+                      {
+                        "description": "This allows full recursive write access to the complete application folders, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-app-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-app-write-recursive",
+                        "markdownDescription": "This allows full recursive write access to the complete application folders, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-app-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to metadata of the `$APPCACHE` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-appcache-index`",
+                        "type": "string",
+                        "const": "fs:allow-appcache-meta",
+                        "markdownDescription": "This allows non-recursive read access to metadata of the `$APPCACHE` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-appcache-index`"
+                      },
+                      {
+                        "description": "This allows full recursive read access to metadata of the `$APPCACHE` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-appcache-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-appcache-meta-recursive",
+                        "markdownDescription": "This allows full recursive read access to metadata of the `$APPCACHE` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-appcache-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to the `$APPCACHE` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-appcache`",
+                        "type": "string",
+                        "const": "fs:allow-appcache-read",
+                        "markdownDescription": "This allows non-recursive read access to the `$APPCACHE` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-appcache`"
+                      },
+                      {
+                        "description": "This allows full recursive read access to the complete `$APPCACHE` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-appcache-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-appcache-read-recursive",
+                        "markdownDescription": "This allows full recursive read access to the complete `$APPCACHE` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-appcache-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive write access to the `$APPCACHE` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-appcache`",
+                        "type": "string",
+                        "const": "fs:allow-appcache-write",
+                        "markdownDescription": "This allows non-recursive write access to the `$APPCACHE` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-appcache`"
+                      },
+                      {
+                        "description": "This allows full recursive write access to the complete `$APPCACHE` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-appcache-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-appcache-write-recursive",
+                        "markdownDescription": "This allows full recursive write access to the complete `$APPCACHE` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-appcache-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to metadata of the `$APPCONFIG` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-appconfig-index`",
+                        "type": "string",
+                        "const": "fs:allow-appconfig-meta",
+                        "markdownDescription": "This allows non-recursive read access to metadata of the `$APPCONFIG` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-appconfig-index`"
+                      },
+                      {
+                        "description": "This allows full recursive read access to metadata of the `$APPCONFIG` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-appconfig-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-appconfig-meta-recursive",
+                        "markdownDescription": "This allows full recursive read access to metadata of the `$APPCONFIG` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-appconfig-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to the `$APPCONFIG` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-appconfig`",
+                        "type": "string",
+                        "const": "fs:allow-appconfig-read",
+                        "markdownDescription": "This allows non-recursive read access to the `$APPCONFIG` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-appconfig`"
+                      },
+                      {
+                        "description": "This allows full recursive read access to the complete `$APPCONFIG` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-appconfig-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-appconfig-read-recursive",
+                        "markdownDescription": "This allows full recursive read access to the complete `$APPCONFIG` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-appconfig-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive write access to the `$APPCONFIG` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-appconfig`",
+                        "type": "string",
+                        "const": "fs:allow-appconfig-write",
+                        "markdownDescription": "This allows non-recursive write access to the `$APPCONFIG` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-appconfig`"
+                      },
+                      {
+                        "description": "This allows full recursive write access to the complete `$APPCONFIG` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-appconfig-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-appconfig-write-recursive",
+                        "markdownDescription": "This allows full recursive write access to the complete `$APPCONFIG` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-appconfig-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to metadata of the `$APPDATA` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-appdata-index`",
+                        "type": "string",
+                        "const": "fs:allow-appdata-meta",
+                        "markdownDescription": "This allows non-recursive read access to metadata of the `$APPDATA` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-appdata-index`"
+                      },
+                      {
+                        "description": "This allows full recursive read access to metadata of the `$APPDATA` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-appdata-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-appdata-meta-recursive",
+                        "markdownDescription": "This allows full recursive read access to metadata of the `$APPDATA` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-appdata-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to the `$APPDATA` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-appdata`",
+                        "type": "string",
+                        "const": "fs:allow-appdata-read",
+                        "markdownDescription": "This allows non-recursive read access to the `$APPDATA` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-appdata`"
+                      },
+                      {
+                        "description": "This allows full recursive read access to the complete `$APPDATA` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-appdata-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-appdata-read-recursive",
+                        "markdownDescription": "This allows full recursive read access to the complete `$APPDATA` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-appdata-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive write access to the `$APPDATA` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-appdata`",
+                        "type": "string",
+                        "const": "fs:allow-appdata-write",
+                        "markdownDescription": "This allows non-recursive write access to the `$APPDATA` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-appdata`"
+                      },
+                      {
+                        "description": "This allows full recursive write access to the complete `$APPDATA` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-appdata-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-appdata-write-recursive",
+                        "markdownDescription": "This allows full recursive write access to the complete `$APPDATA` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-appdata-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to metadata of the `$APPLOCALDATA` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-applocaldata-index`",
+                        "type": "string",
+                        "const": "fs:allow-applocaldata-meta",
+                        "markdownDescription": "This allows non-recursive read access to metadata of the `$APPLOCALDATA` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-applocaldata-index`"
+                      },
+                      {
+                        "description": "This allows full recursive read access to metadata of the `$APPLOCALDATA` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-applocaldata-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-applocaldata-meta-recursive",
+                        "markdownDescription": "This allows full recursive read access to metadata of the `$APPLOCALDATA` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-applocaldata-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to the `$APPLOCALDATA` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-applocaldata`",
+                        "type": "string",
+                        "const": "fs:allow-applocaldata-read",
+                        "markdownDescription": "This allows non-recursive read access to the `$APPLOCALDATA` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-applocaldata`"
+                      },
+                      {
+                        "description": "This allows full recursive read access to the complete `$APPLOCALDATA` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-applocaldata-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-applocaldata-read-recursive",
+                        "markdownDescription": "This allows full recursive read access to the complete `$APPLOCALDATA` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-applocaldata-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive write access to the `$APPLOCALDATA` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-applocaldata`",
+                        "type": "string",
+                        "const": "fs:allow-applocaldata-write",
+                        "markdownDescription": "This allows non-recursive write access to the `$APPLOCALDATA` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-applocaldata`"
+                      },
+                      {
+                        "description": "This allows full recursive write access to the complete `$APPLOCALDATA` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-applocaldata-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-applocaldata-write-recursive",
+                        "markdownDescription": "This allows full recursive write access to the complete `$APPLOCALDATA` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-applocaldata-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to metadata of the `$APPLOG` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-applog-index`",
+                        "type": "string",
+                        "const": "fs:allow-applog-meta",
+                        "markdownDescription": "This allows non-recursive read access to metadata of the `$APPLOG` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-applog-index`"
+                      },
+                      {
+                        "description": "This allows full recursive read access to metadata of the `$APPLOG` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-applog-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-applog-meta-recursive",
+                        "markdownDescription": "This allows full recursive read access to metadata of the `$APPLOG` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-applog-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to the `$APPLOG` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-applog`",
+                        "type": "string",
+                        "const": "fs:allow-applog-read",
+                        "markdownDescription": "This allows non-recursive read access to the `$APPLOG` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-applog`"
+                      },
+                      {
+                        "description": "This allows full recursive read access to the complete `$APPLOG` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-applog-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-applog-read-recursive",
+                        "markdownDescription": "This allows full recursive read access to the complete `$APPLOG` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-applog-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive write access to the `$APPLOG` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-applog`",
+                        "type": "string",
+                        "const": "fs:allow-applog-write",
+                        "markdownDescription": "This allows non-recursive write access to the `$APPLOG` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-applog`"
+                      },
+                      {
+                        "description": "This allows full recursive write access to the complete `$APPLOG` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-applog-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-applog-write-recursive",
+                        "markdownDescription": "This allows full recursive write access to the complete `$APPLOG` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-applog-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to metadata of the `$AUDIO` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-audio-index`",
+                        "type": "string",
+                        "const": "fs:allow-audio-meta",
+                        "markdownDescription": "This allows non-recursive read access to metadata of the `$AUDIO` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-audio-index`"
+                      },
+                      {
+                        "description": "This allows full recursive read access to metadata of the `$AUDIO` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-audio-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-audio-meta-recursive",
+                        "markdownDescription": "This allows full recursive read access to metadata of the `$AUDIO` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-audio-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to the `$AUDIO` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-audio`",
+                        "type": "string",
+                        "const": "fs:allow-audio-read",
+                        "markdownDescription": "This allows non-recursive read access to the `$AUDIO` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-audio`"
+                      },
+                      {
+                        "description": "This allows full recursive read access to the complete `$AUDIO` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-audio-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-audio-read-recursive",
+                        "markdownDescription": "This allows full recursive read access to the complete `$AUDIO` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-audio-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive write access to the `$AUDIO` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-audio`",
+                        "type": "string",
+                        "const": "fs:allow-audio-write",
+                        "markdownDescription": "This allows non-recursive write access to the `$AUDIO` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-audio`"
+                      },
+                      {
+                        "description": "This allows full recursive write access to the complete `$AUDIO` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-audio-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-audio-write-recursive",
+                        "markdownDescription": "This allows full recursive write access to the complete `$AUDIO` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-audio-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to metadata of the `$CACHE` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-cache-index`",
+                        "type": "string",
+                        "const": "fs:allow-cache-meta",
+                        "markdownDescription": "This allows non-recursive read access to metadata of the `$CACHE` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-cache-index`"
+                      },
+                      {
+                        "description": "This allows full recursive read access to metadata of the `$CACHE` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-cache-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-cache-meta-recursive",
+                        "markdownDescription": "This allows full recursive read access to metadata of the `$CACHE` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-cache-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to the `$CACHE` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-cache`",
+                        "type": "string",
+                        "const": "fs:allow-cache-read",
+                        "markdownDescription": "This allows non-recursive read access to the `$CACHE` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-cache`"
+                      },
+                      {
+                        "description": "This allows full recursive read access to the complete `$CACHE` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-cache-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-cache-read-recursive",
+                        "markdownDescription": "This allows full recursive read access to the complete `$CACHE` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-cache-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive write access to the `$CACHE` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-cache`",
+                        "type": "string",
+                        "const": "fs:allow-cache-write",
+                        "markdownDescription": "This allows non-recursive write access to the `$CACHE` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-cache`"
+                      },
+                      {
+                        "description": "This allows full recursive write access to the complete `$CACHE` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-cache-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-cache-write-recursive",
+                        "markdownDescription": "This allows full recursive write access to the complete `$CACHE` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-cache-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to metadata of the `$CONFIG` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-config-index`",
+                        "type": "string",
+                        "const": "fs:allow-config-meta",
+                        "markdownDescription": "This allows non-recursive read access to metadata of the `$CONFIG` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-config-index`"
+                      },
+                      {
+                        "description": "This allows full recursive read access to metadata of the `$CONFIG` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-config-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-config-meta-recursive",
+                        "markdownDescription": "This allows full recursive read access to metadata of the `$CONFIG` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-config-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to the `$CONFIG` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-config`",
+                        "type": "string",
+                        "const": "fs:allow-config-read",
+                        "markdownDescription": "This allows non-recursive read access to the `$CONFIG` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-config`"
+                      },
+                      {
+                        "description": "This allows full recursive read access to the complete `$CONFIG` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-config-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-config-read-recursive",
+                        "markdownDescription": "This allows full recursive read access to the complete `$CONFIG` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-config-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive write access to the `$CONFIG` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-config`",
+                        "type": "string",
+                        "const": "fs:allow-config-write",
+                        "markdownDescription": "This allows non-recursive write access to the `$CONFIG` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-config`"
+                      },
+                      {
+                        "description": "This allows full recursive write access to the complete `$CONFIG` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-config-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-config-write-recursive",
+                        "markdownDescription": "This allows full recursive write access to the complete `$CONFIG` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-config-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to metadata of the `$DATA` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-data-index`",
+                        "type": "string",
+                        "const": "fs:allow-data-meta",
+                        "markdownDescription": "This allows non-recursive read access to metadata of the `$DATA` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-data-index`"
+                      },
+                      {
+                        "description": "This allows full recursive read access to metadata of the `$DATA` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-data-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-data-meta-recursive",
+                        "markdownDescription": "This allows full recursive read access to metadata of the `$DATA` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-data-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to the `$DATA` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-data`",
+                        "type": "string",
+                        "const": "fs:allow-data-read",
+                        "markdownDescription": "This allows non-recursive read access to the `$DATA` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-data`"
+                      },
+                      {
+                        "description": "This allows full recursive read access to the complete `$DATA` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-data-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-data-read-recursive",
+                        "markdownDescription": "This allows full recursive read access to the complete `$DATA` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-data-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive write access to the `$DATA` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-data`",
+                        "type": "string",
+                        "const": "fs:allow-data-write",
+                        "markdownDescription": "This allows non-recursive write access to the `$DATA` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-data`"
+                      },
+                      {
+                        "description": "This allows full recursive write access to the complete `$DATA` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-data-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-data-write-recursive",
+                        "markdownDescription": "This allows full recursive write access to the complete `$DATA` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-data-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to metadata of the `$DESKTOP` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-desktop-index`",
+                        "type": "string",
+                        "const": "fs:allow-desktop-meta",
+                        "markdownDescription": "This allows non-recursive read access to metadata of the `$DESKTOP` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-desktop-index`"
+                      },
+                      {
+                        "description": "This allows full recursive read access to metadata of the `$DESKTOP` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-desktop-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-desktop-meta-recursive",
+                        "markdownDescription": "This allows full recursive read access to metadata of the `$DESKTOP` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-desktop-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to the `$DESKTOP` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-desktop`",
+                        "type": "string",
+                        "const": "fs:allow-desktop-read",
+                        "markdownDescription": "This allows non-recursive read access to the `$DESKTOP` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-desktop`"
+                      },
+                      {
+                        "description": "This allows full recursive read access to the complete `$DESKTOP` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-desktop-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-desktop-read-recursive",
+                        "markdownDescription": "This allows full recursive read access to the complete `$DESKTOP` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-desktop-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive write access to the `$DESKTOP` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-desktop`",
+                        "type": "string",
+                        "const": "fs:allow-desktop-write",
+                        "markdownDescription": "This allows non-recursive write access to the `$DESKTOP` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-desktop`"
+                      },
+                      {
+                        "description": "This allows full recursive write access to the complete `$DESKTOP` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-desktop-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-desktop-write-recursive",
+                        "markdownDescription": "This allows full recursive write access to the complete `$DESKTOP` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-desktop-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to metadata of the `$DOCUMENT` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-document-index`",
+                        "type": "string",
+                        "const": "fs:allow-document-meta",
+                        "markdownDescription": "This allows non-recursive read access to metadata of the `$DOCUMENT` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-document-index`"
+                      },
+                      {
+                        "description": "This allows full recursive read access to metadata of the `$DOCUMENT` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-document-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-document-meta-recursive",
+                        "markdownDescription": "This allows full recursive read access to metadata of the `$DOCUMENT` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-document-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to the `$DOCUMENT` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-document`",
+                        "type": "string",
+                        "const": "fs:allow-document-read",
+                        "markdownDescription": "This allows non-recursive read access to the `$DOCUMENT` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-document`"
+                      },
+                      {
+                        "description": "This allows full recursive read access to the complete `$DOCUMENT` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-document-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-document-read-recursive",
+                        "markdownDescription": "This allows full recursive read access to the complete `$DOCUMENT` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-document-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive write access to the `$DOCUMENT` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-document`",
+                        "type": "string",
+                        "const": "fs:allow-document-write",
+                        "markdownDescription": "This allows non-recursive write access to the `$DOCUMENT` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-document`"
+                      },
+                      {
+                        "description": "This allows full recursive write access to the complete `$DOCUMENT` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-document-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-document-write-recursive",
+                        "markdownDescription": "This allows full recursive write access to the complete `$DOCUMENT` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-document-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to metadata of the `$DOWNLOAD` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-download-index`",
+                        "type": "string",
+                        "const": "fs:allow-download-meta",
+                        "markdownDescription": "This allows non-recursive read access to metadata of the `$DOWNLOAD` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-download-index`"
+                      },
+                      {
+                        "description": "This allows full recursive read access to metadata of the `$DOWNLOAD` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-download-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-download-meta-recursive",
+                        "markdownDescription": "This allows full recursive read access to metadata of the `$DOWNLOAD` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-download-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to the `$DOWNLOAD` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-download`",
+                        "type": "string",
+                        "const": "fs:allow-download-read",
+                        "markdownDescription": "This allows non-recursive read access to the `$DOWNLOAD` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-download`"
+                      },
+                      {
+                        "description": "This allows full recursive read access to the complete `$DOWNLOAD` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-download-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-download-read-recursive",
+                        "markdownDescription": "This allows full recursive read access to the complete `$DOWNLOAD` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-download-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive write access to the `$DOWNLOAD` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-download`",
+                        "type": "string",
+                        "const": "fs:allow-download-write",
+                        "markdownDescription": "This allows non-recursive write access to the `$DOWNLOAD` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-download`"
+                      },
+                      {
+                        "description": "This allows full recursive write access to the complete `$DOWNLOAD` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-download-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-download-write-recursive",
+                        "markdownDescription": "This allows full recursive write access to the complete `$DOWNLOAD` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-download-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to metadata of the `$EXE` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-exe-index`",
+                        "type": "string",
+                        "const": "fs:allow-exe-meta",
+                        "markdownDescription": "This allows non-recursive read access to metadata of the `$EXE` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-exe-index`"
+                      },
+                      {
+                        "description": "This allows full recursive read access to metadata of the `$EXE` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-exe-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-exe-meta-recursive",
+                        "markdownDescription": "This allows full recursive read access to metadata of the `$EXE` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-exe-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to the `$EXE` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-exe`",
+                        "type": "string",
+                        "const": "fs:allow-exe-read",
+                        "markdownDescription": "This allows non-recursive read access to the `$EXE` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-exe`"
+                      },
+                      {
+                        "description": "This allows full recursive read access to the complete `$EXE` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-exe-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-exe-read-recursive",
+                        "markdownDescription": "This allows full recursive read access to the complete `$EXE` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-exe-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive write access to the `$EXE` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-exe`",
+                        "type": "string",
+                        "const": "fs:allow-exe-write",
+                        "markdownDescription": "This allows non-recursive write access to the `$EXE` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-exe`"
+                      },
+                      {
+                        "description": "This allows full recursive write access to the complete `$EXE` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-exe-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-exe-write-recursive",
+                        "markdownDescription": "This allows full recursive write access to the complete `$EXE` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-exe-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to metadata of the `$FONT` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-font-index`",
+                        "type": "string",
+                        "const": "fs:allow-font-meta",
+                        "markdownDescription": "This allows non-recursive read access to metadata of the `$FONT` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-font-index`"
+                      },
+                      {
+                        "description": "This allows full recursive read access to metadata of the `$FONT` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-font-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-font-meta-recursive",
+                        "markdownDescription": "This allows full recursive read access to metadata of the `$FONT` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-font-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to the `$FONT` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-font`",
+                        "type": "string",
+                        "const": "fs:allow-font-read",
+                        "markdownDescription": "This allows non-recursive read access to the `$FONT` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-font`"
+                      },
+                      {
+                        "description": "This allows full recursive read access to the complete `$FONT` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-font-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-font-read-recursive",
+                        "markdownDescription": "This allows full recursive read access to the complete `$FONT` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-font-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive write access to the `$FONT` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-font`",
+                        "type": "string",
+                        "const": "fs:allow-font-write",
+                        "markdownDescription": "This allows non-recursive write access to the `$FONT` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-font`"
+                      },
+                      {
+                        "description": "This allows full recursive write access to the complete `$FONT` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-font-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-font-write-recursive",
+                        "markdownDescription": "This allows full recursive write access to the complete `$FONT` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-font-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to metadata of the `$HOME` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-home-index`",
+                        "type": "string",
+                        "const": "fs:allow-home-meta",
+                        "markdownDescription": "This allows non-recursive read access to metadata of the `$HOME` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-home-index`"
+                      },
+                      {
+                        "description": "This allows full recursive read access to metadata of the `$HOME` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-home-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-home-meta-recursive",
+                        "markdownDescription": "This allows full recursive read access to metadata of the `$HOME` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-home-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to the `$HOME` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-home`",
+                        "type": "string",
+                        "const": "fs:allow-home-read",
+                        "markdownDescription": "This allows non-recursive read access to the `$HOME` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-home`"
+                      },
+                      {
+                        "description": "This allows full recursive read access to the complete `$HOME` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-home-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-home-read-recursive",
+                        "markdownDescription": "This allows full recursive read access to the complete `$HOME` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-home-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive write access to the `$HOME` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-home`",
+                        "type": "string",
+                        "const": "fs:allow-home-write",
+                        "markdownDescription": "This allows non-recursive write access to the `$HOME` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-home`"
+                      },
+                      {
+                        "description": "This allows full recursive write access to the complete `$HOME` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-home-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-home-write-recursive",
+                        "markdownDescription": "This allows full recursive write access to the complete `$HOME` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-home-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to metadata of the `$LOCALDATA` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-localdata-index`",
+                        "type": "string",
+                        "const": "fs:allow-localdata-meta",
+                        "markdownDescription": "This allows non-recursive read access to metadata of the `$LOCALDATA` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-localdata-index`"
+                      },
+                      {
+                        "description": "This allows full recursive read access to metadata of the `$LOCALDATA` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-localdata-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-localdata-meta-recursive",
+                        "markdownDescription": "This allows full recursive read access to metadata of the `$LOCALDATA` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-localdata-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to the `$LOCALDATA` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-localdata`",
+                        "type": "string",
+                        "const": "fs:allow-localdata-read",
+                        "markdownDescription": "This allows non-recursive read access to the `$LOCALDATA` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-localdata`"
+                      },
+                      {
+                        "description": "This allows full recursive read access to the complete `$LOCALDATA` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-localdata-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-localdata-read-recursive",
+                        "markdownDescription": "This allows full recursive read access to the complete `$LOCALDATA` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-localdata-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive write access to the `$LOCALDATA` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-localdata`",
+                        "type": "string",
+                        "const": "fs:allow-localdata-write",
+                        "markdownDescription": "This allows non-recursive write access to the `$LOCALDATA` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-localdata`"
+                      },
+                      {
+                        "description": "This allows full recursive write access to the complete `$LOCALDATA` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-localdata-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-localdata-write-recursive",
+                        "markdownDescription": "This allows full recursive write access to the complete `$LOCALDATA` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-localdata-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to metadata of the `$LOG` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-log-index`",
+                        "type": "string",
+                        "const": "fs:allow-log-meta",
+                        "markdownDescription": "This allows non-recursive read access to metadata of the `$LOG` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-log-index`"
+                      },
+                      {
+                        "description": "This allows full recursive read access to metadata of the `$LOG` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-log-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-log-meta-recursive",
+                        "markdownDescription": "This allows full recursive read access to metadata of the `$LOG` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-log-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to the `$LOG` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-log`",
+                        "type": "string",
+                        "const": "fs:allow-log-read",
+                        "markdownDescription": "This allows non-recursive read access to the `$LOG` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-log`"
+                      },
+                      {
+                        "description": "This allows full recursive read access to the complete `$LOG` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-log-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-log-read-recursive",
+                        "markdownDescription": "This allows full recursive read access to the complete `$LOG` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-log-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive write access to the `$LOG` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-log`",
+                        "type": "string",
+                        "const": "fs:allow-log-write",
+                        "markdownDescription": "This allows non-recursive write access to the `$LOG` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-log`"
+                      },
+                      {
+                        "description": "This allows full recursive write access to the complete `$LOG` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-log-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-log-write-recursive",
+                        "markdownDescription": "This allows full recursive write access to the complete `$LOG` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-log-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to metadata of the `$PICTURE` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-picture-index`",
+                        "type": "string",
+                        "const": "fs:allow-picture-meta",
+                        "markdownDescription": "This allows non-recursive read access to metadata of the `$PICTURE` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-picture-index`"
+                      },
+                      {
+                        "description": "This allows full recursive read access to metadata of the `$PICTURE` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-picture-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-picture-meta-recursive",
+                        "markdownDescription": "This allows full recursive read access to metadata of the `$PICTURE` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-picture-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to the `$PICTURE` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-picture`",
+                        "type": "string",
+                        "const": "fs:allow-picture-read",
+                        "markdownDescription": "This allows non-recursive read access to the `$PICTURE` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-picture`"
+                      },
+                      {
+                        "description": "This allows full recursive read access to the complete `$PICTURE` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-picture-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-picture-read-recursive",
+                        "markdownDescription": "This allows full recursive read access to the complete `$PICTURE` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-picture-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive write access to the `$PICTURE` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-picture`",
+                        "type": "string",
+                        "const": "fs:allow-picture-write",
+                        "markdownDescription": "This allows non-recursive write access to the `$PICTURE` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-picture`"
+                      },
+                      {
+                        "description": "This allows full recursive write access to the complete `$PICTURE` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-picture-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-picture-write-recursive",
+                        "markdownDescription": "This allows full recursive write access to the complete `$PICTURE` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-picture-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to metadata of the `$PUBLIC` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-public-index`",
+                        "type": "string",
+                        "const": "fs:allow-public-meta",
+                        "markdownDescription": "This allows non-recursive read access to metadata of the `$PUBLIC` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-public-index`"
+                      },
+                      {
+                        "description": "This allows full recursive read access to metadata of the `$PUBLIC` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-public-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-public-meta-recursive",
+                        "markdownDescription": "This allows full recursive read access to metadata of the `$PUBLIC` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-public-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to the `$PUBLIC` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-public`",
+                        "type": "string",
+                        "const": "fs:allow-public-read",
+                        "markdownDescription": "This allows non-recursive read access to the `$PUBLIC` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-public`"
+                      },
+                      {
+                        "description": "This allows full recursive read access to the complete `$PUBLIC` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-public-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-public-read-recursive",
+                        "markdownDescription": "This allows full recursive read access to the complete `$PUBLIC` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-public-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive write access to the `$PUBLIC` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-public`",
+                        "type": "string",
+                        "const": "fs:allow-public-write",
+                        "markdownDescription": "This allows non-recursive write access to the `$PUBLIC` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-public`"
+                      },
+                      {
+                        "description": "This allows full recursive write access to the complete `$PUBLIC` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-public-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-public-write-recursive",
+                        "markdownDescription": "This allows full recursive write access to the complete `$PUBLIC` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-public-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to metadata of the `$RESOURCE` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-resource-index`",
+                        "type": "string",
+                        "const": "fs:allow-resource-meta",
+                        "markdownDescription": "This allows non-recursive read access to metadata of the `$RESOURCE` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-resource-index`"
+                      },
+                      {
+                        "description": "This allows full recursive read access to metadata of the `$RESOURCE` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-resource-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-resource-meta-recursive",
+                        "markdownDescription": "This allows full recursive read access to metadata of the `$RESOURCE` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-resource-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to the `$RESOURCE` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-resource`",
+                        "type": "string",
+                        "const": "fs:allow-resource-read",
+                        "markdownDescription": "This allows non-recursive read access to the `$RESOURCE` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-resource`"
+                      },
+                      {
+                        "description": "This allows full recursive read access to the complete `$RESOURCE` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-resource-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-resource-read-recursive",
+                        "markdownDescription": "This allows full recursive read access to the complete `$RESOURCE` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-resource-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive write access to the `$RESOURCE` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-resource`",
+                        "type": "string",
+                        "const": "fs:allow-resource-write",
+                        "markdownDescription": "This allows non-recursive write access to the `$RESOURCE` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-resource`"
+                      },
+                      {
+                        "description": "This allows full recursive write access to the complete `$RESOURCE` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-resource-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-resource-write-recursive",
+                        "markdownDescription": "This allows full recursive write access to the complete `$RESOURCE` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-resource-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to metadata of the `$RUNTIME` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-runtime-index`",
+                        "type": "string",
+                        "const": "fs:allow-runtime-meta",
+                        "markdownDescription": "This allows non-recursive read access to metadata of the `$RUNTIME` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-runtime-index`"
+                      },
+                      {
+                        "description": "This allows full recursive read access to metadata of the `$RUNTIME` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-runtime-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-runtime-meta-recursive",
+                        "markdownDescription": "This allows full recursive read access to metadata of the `$RUNTIME` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-runtime-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to the `$RUNTIME` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-runtime`",
+                        "type": "string",
+                        "const": "fs:allow-runtime-read",
+                        "markdownDescription": "This allows non-recursive read access to the `$RUNTIME` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-runtime`"
+                      },
+                      {
+                        "description": "This allows full recursive read access to the complete `$RUNTIME` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-runtime-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-runtime-read-recursive",
+                        "markdownDescription": "This allows full recursive read access to the complete `$RUNTIME` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-runtime-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive write access to the `$RUNTIME` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-runtime`",
+                        "type": "string",
+                        "const": "fs:allow-runtime-write",
+                        "markdownDescription": "This allows non-recursive write access to the `$RUNTIME` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-runtime`"
+                      },
+                      {
+                        "description": "This allows full recursive write access to the complete `$RUNTIME` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-runtime-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-runtime-write-recursive",
+                        "markdownDescription": "This allows full recursive write access to the complete `$RUNTIME` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-runtime-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to metadata of the `$TEMP` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-temp-index`",
+                        "type": "string",
+                        "const": "fs:allow-temp-meta",
+                        "markdownDescription": "This allows non-recursive read access to metadata of the `$TEMP` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-temp-index`"
+                      },
+                      {
+                        "description": "This allows full recursive read access to metadata of the `$TEMP` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-temp-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-temp-meta-recursive",
+                        "markdownDescription": "This allows full recursive read access to metadata of the `$TEMP` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-temp-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to the `$TEMP` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-temp`",
+                        "type": "string",
+                        "const": "fs:allow-temp-read",
+                        "markdownDescription": "This allows non-recursive read access to the `$TEMP` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-temp`"
+                      },
+                      {
+                        "description": "This allows full recursive read access to the complete `$TEMP` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-temp-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-temp-read-recursive",
+                        "markdownDescription": "This allows full recursive read access to the complete `$TEMP` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-temp-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive write access to the `$TEMP` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-temp`",
+                        "type": "string",
+                        "const": "fs:allow-temp-write",
+                        "markdownDescription": "This allows non-recursive write access to the `$TEMP` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-temp`"
+                      },
+                      {
+                        "description": "This allows full recursive write access to the complete `$TEMP` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-temp-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-temp-write-recursive",
+                        "markdownDescription": "This allows full recursive write access to the complete `$TEMP` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-temp-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to metadata of the `$TEMPLATE` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-template-index`",
+                        "type": "string",
+                        "const": "fs:allow-template-meta",
+                        "markdownDescription": "This allows non-recursive read access to metadata of the `$TEMPLATE` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-template-index`"
+                      },
+                      {
+                        "description": "This allows full recursive read access to metadata of the `$TEMPLATE` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-template-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-template-meta-recursive",
+                        "markdownDescription": "This allows full recursive read access to metadata of the `$TEMPLATE` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-template-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to the `$TEMPLATE` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-template`",
+                        "type": "string",
+                        "const": "fs:allow-template-read",
+                        "markdownDescription": "This allows non-recursive read access to the `$TEMPLATE` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-template`"
+                      },
+                      {
+                        "description": "This allows full recursive read access to the complete `$TEMPLATE` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-template-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-template-read-recursive",
+                        "markdownDescription": "This allows full recursive read access to the complete `$TEMPLATE` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-template-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive write access to the `$TEMPLATE` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-template`",
+                        "type": "string",
+                        "const": "fs:allow-template-write",
+                        "markdownDescription": "This allows non-recursive write access to the `$TEMPLATE` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-template`"
+                      },
+                      {
+                        "description": "This allows full recursive write access to the complete `$TEMPLATE` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-template-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-template-write-recursive",
+                        "markdownDescription": "This allows full recursive write access to the complete `$TEMPLATE` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-template-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to metadata of the `$VIDEO` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-video-index`",
+                        "type": "string",
+                        "const": "fs:allow-video-meta",
+                        "markdownDescription": "This allows non-recursive read access to metadata of the `$VIDEO` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-video-index`"
+                      },
+                      {
+                        "description": "This allows full recursive read access to metadata of the `$VIDEO` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-video-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-video-meta-recursive",
+                        "markdownDescription": "This allows full recursive read access to metadata of the `$VIDEO` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-video-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to the `$VIDEO` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-video`",
+                        "type": "string",
+                        "const": "fs:allow-video-read",
+                        "markdownDescription": "This allows non-recursive read access to the `$VIDEO` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-video`"
+                      },
+                      {
+                        "description": "This allows full recursive read access to the complete `$VIDEO` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-video-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-video-read-recursive",
+                        "markdownDescription": "This allows full recursive read access to the complete `$VIDEO` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-video-recursive`"
+                      },
+                      {
+                        "description": "This allows non-recursive write access to the `$VIDEO` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-video`",
+                        "type": "string",
+                        "const": "fs:allow-video-write",
+                        "markdownDescription": "This allows non-recursive write access to the `$VIDEO` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-video`"
+                      },
+                      {
+                        "description": "This allows full recursive write access to the complete `$VIDEO` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-video-recursive`",
+                        "type": "string",
+                        "const": "fs:allow-video-write-recursive",
+                        "markdownDescription": "This allows full recursive write access to the complete `$VIDEO` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-video-recursive`"
+                      },
+                      {
+                        "description": "This denies access to dangerous Tauri relevant files and folders by default.\n#### This permission set includes:\n\n- `deny-webview-data-linux`\n- `deny-webview-data-windows`",
+                        "type": "string",
+                        "const": "fs:deny-default",
+                        "markdownDescription": "This denies access to dangerous Tauri relevant files and folders by default.\n#### This permission set includes:\n\n- `deny-webview-data-linux`\n- `deny-webview-data-windows`"
+                      },
+                      {
+                        "description": "Enables the copy_file command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:allow-copy-file",
+                        "markdownDescription": "Enables the copy_file command without any pre-configured scope."
+                      },
+                      {
+                        "description": "Enables the create command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:allow-create",
+                        "markdownDescription": "Enables the create command without any pre-configured scope."
+                      },
+                      {
+                        "description": "Enables the exists command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:allow-exists",
+                        "markdownDescription": "Enables the exists command without any pre-configured scope."
+                      },
+                      {
+                        "description": "Enables the fstat command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:allow-fstat",
+                        "markdownDescription": "Enables the fstat command without any pre-configured scope."
+                      },
+                      {
+                        "description": "Enables the ftruncate command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:allow-ftruncate",
+                        "markdownDescription": "Enables the ftruncate command without any pre-configured scope."
+                      },
+                      {
+                        "description": "Enables the lstat command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:allow-lstat",
+                        "markdownDescription": "Enables the lstat command without any pre-configured scope."
+                      },
+                      {
+                        "description": "Enables the mkdir command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:allow-mkdir",
+                        "markdownDescription": "Enables the mkdir command without any pre-configured scope."
+                      },
+                      {
+                        "description": "Enables the open command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:allow-open",
+                        "markdownDescription": "Enables the open command without any pre-configured scope."
+                      },
+                      {
+                        "description": "Enables the read command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:allow-read",
+                        "markdownDescription": "Enables the read command without any pre-configured scope."
+                      },
+                      {
+                        "description": "Enables the read_dir command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:allow-read-dir",
+                        "markdownDescription": "Enables the read_dir command without any pre-configured scope."
+                      },
+                      {
+                        "description": "Enables the read_file command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:allow-read-file",
+                        "markdownDescription": "Enables the read_file command without any pre-configured scope."
+                      },
+                      {
+                        "description": "Enables the read_text_file command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:allow-read-text-file",
+                        "markdownDescription": "Enables the read_text_file command without any pre-configured scope."
+                      },
+                      {
+                        "description": "Enables the read_text_file_lines command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:allow-read-text-file-lines",
+                        "markdownDescription": "Enables the read_text_file_lines command without any pre-configured scope."
+                      },
+                      {
+                        "description": "Enables the read_text_file_lines_next command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:allow-read-text-file-lines-next",
+                        "markdownDescription": "Enables the read_text_file_lines_next command without any pre-configured scope."
+                      },
+                      {
+                        "description": "Enables the remove command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:allow-remove",
+                        "markdownDescription": "Enables the remove command without any pre-configured scope."
+                      },
+                      {
+                        "description": "Enables the rename command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:allow-rename",
+                        "markdownDescription": "Enables the rename command without any pre-configured scope."
+                      },
+                      {
+                        "description": "Enables the seek command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:allow-seek",
+                        "markdownDescription": "Enables the seek command without any pre-configured scope."
+                      },
+                      {
+                        "description": "Enables the size command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:allow-size",
+                        "markdownDescription": "Enables the size command without any pre-configured scope."
+                      },
+                      {
+                        "description": "Enables the start_accessing_security_scoped_resource command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:allow-start-accessing-security-scoped-resource",
+                        "markdownDescription": "Enables the start_accessing_security_scoped_resource command without any pre-configured scope."
+                      },
+                      {
+                        "description": "Enables the stat command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:allow-stat",
+                        "markdownDescription": "Enables the stat command without any pre-configured scope."
+                      },
+                      {
+                        "description": "Enables the stop_accessing_security_scoped_resource command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:allow-stop-accessing-security-scoped-resource",
+                        "markdownDescription": "Enables the stop_accessing_security_scoped_resource command without any pre-configured scope."
+                      },
+                      {
+                        "description": "Enables the truncate command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:allow-truncate",
+                        "markdownDescription": "Enables the truncate command without any pre-configured scope."
+                      },
+                      {
+                        "description": "Enables the unwatch command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:allow-unwatch",
+                        "markdownDescription": "Enables the unwatch command without any pre-configured scope."
+                      },
+                      {
+                        "description": "Enables the watch command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:allow-watch",
+                        "markdownDescription": "Enables the watch command without any pre-configured scope."
+                      },
+                      {
+                        "description": "Enables the write command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:allow-write",
+                        "markdownDescription": "Enables the write command without any pre-configured scope."
+                      },
+                      {
+                        "description": "Enables the write_file command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:allow-write-file",
+                        "markdownDescription": "Enables the write_file command without any pre-configured scope."
+                      },
+                      {
+                        "description": "Enables the write_text_file command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:allow-write-text-file",
+                        "markdownDescription": "Enables the write_text_file command without any pre-configured scope."
+                      },
+                      {
+                        "description": "This permissions allows to create the application specific directories.\n",
+                        "type": "string",
+                        "const": "fs:create-app-specific-dirs",
+                        "markdownDescription": "This permissions allows to create the application specific directories.\n"
+                      },
+                      {
+                        "description": "Denies the copy_file command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:deny-copy-file",
+                        "markdownDescription": "Denies the copy_file command without any pre-configured scope."
+                      },
+                      {
+                        "description": "Denies the create command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:deny-create",
+                        "markdownDescription": "Denies the create command without any pre-configured scope."
+                      },
+                      {
+                        "description": "Denies the exists command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:deny-exists",
+                        "markdownDescription": "Denies the exists command without any pre-configured scope."
+                      },
+                      {
+                        "description": "Denies the fstat command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:deny-fstat",
+                        "markdownDescription": "Denies the fstat command without any pre-configured scope."
+                      },
+                      {
+                        "description": "Denies the ftruncate command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:deny-ftruncate",
+                        "markdownDescription": "Denies the ftruncate command without any pre-configured scope."
+                      },
+                      {
+                        "description": "Denies the lstat command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:deny-lstat",
+                        "markdownDescription": "Denies the lstat command without any pre-configured scope."
+                      },
+                      {
+                        "description": "Denies the mkdir command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:deny-mkdir",
+                        "markdownDescription": "Denies the mkdir command without any pre-configured scope."
+                      },
+                      {
+                        "description": "Denies the open command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:deny-open",
+                        "markdownDescription": "Denies the open command without any pre-configured scope."
+                      },
+                      {
+                        "description": "Denies the read command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:deny-read",
+                        "markdownDescription": "Denies the read command without any pre-configured scope."
+                      },
+                      {
+                        "description": "Denies the read_dir command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:deny-read-dir",
+                        "markdownDescription": "Denies the read_dir command without any pre-configured scope."
+                      },
+                      {
+                        "description": "Denies the read_file command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:deny-read-file",
+                        "markdownDescription": "Denies the read_file command without any pre-configured scope."
+                      },
+                      {
+                        "description": "Denies the read_text_file command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:deny-read-text-file",
+                        "markdownDescription": "Denies the read_text_file command without any pre-configured scope."
+                      },
+                      {
+                        "description": "Denies the read_text_file_lines command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:deny-read-text-file-lines",
+                        "markdownDescription": "Denies the read_text_file_lines command without any pre-configured scope."
+                      },
+                      {
+                        "description": "Denies the read_text_file_lines_next command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:deny-read-text-file-lines-next",
+                        "markdownDescription": "Denies the read_text_file_lines_next command without any pre-configured scope."
+                      },
+                      {
+                        "description": "Denies the remove command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:deny-remove",
+                        "markdownDescription": "Denies the remove command without any pre-configured scope."
+                      },
+                      {
+                        "description": "Denies the rename command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:deny-rename",
+                        "markdownDescription": "Denies the rename command without any pre-configured scope."
+                      },
+                      {
+                        "description": "Denies the seek command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:deny-seek",
+                        "markdownDescription": "Denies the seek command without any pre-configured scope."
+                      },
+                      {
+                        "description": "Denies the size command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:deny-size",
+                        "markdownDescription": "Denies the size command without any pre-configured scope."
+                      },
+                      {
+                        "description": "Denies the start_accessing_security_scoped_resource command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:deny-start-accessing-security-scoped-resource",
+                        "markdownDescription": "Denies the start_accessing_security_scoped_resource command without any pre-configured scope."
+                      },
+                      {
+                        "description": "Denies the stat command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:deny-stat",
+                        "markdownDescription": "Denies the stat command without any pre-configured scope."
+                      },
+                      {
+                        "description": "Denies the stop_accessing_security_scoped_resource command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:deny-stop-accessing-security-scoped-resource",
+                        "markdownDescription": "Denies the stop_accessing_security_scoped_resource command without any pre-configured scope."
+                      },
+                      {
+                        "description": "Denies the truncate command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:deny-truncate",
+                        "markdownDescription": "Denies the truncate command without any pre-configured scope."
+                      },
+                      {
+                        "description": "Denies the unwatch command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:deny-unwatch",
+                        "markdownDescription": "Denies the unwatch command without any pre-configured scope."
+                      },
+                      {
+                        "description": "Denies the watch command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:deny-watch",
+                        "markdownDescription": "Denies the watch command without any pre-configured scope."
+                      },
+                      {
+                        "description": "This denies read access to the\n`$APPLOCALDATA` folder on linux as the webview data and configuration values are stored here.\nAllowing access can lead to sensitive information disclosure and should be well considered.",
+                        "type": "string",
+                        "const": "fs:deny-webview-data-linux",
+                        "markdownDescription": "This denies read access to the\n`$APPLOCALDATA` folder on linux as the webview data and configuration values are stored here.\nAllowing access can lead to sensitive information disclosure and should be well considered."
+                      },
+                      {
+                        "description": "This denies read access to the\n`$APPLOCALDATA/EBWebView` folder on windows as the webview data and configuration values are stored here.\nAllowing access can lead to sensitive information disclosure and should be well considered.",
+                        "type": "string",
+                        "const": "fs:deny-webview-data-windows",
+                        "markdownDescription": "This denies read access to the\n`$APPLOCALDATA/EBWebView` folder on windows as the webview data and configuration values are stored here.\nAllowing access can lead to sensitive information disclosure and should be well considered."
+                      },
+                      {
+                        "description": "Denies the write command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:deny-write",
+                        "markdownDescription": "Denies the write command without any pre-configured scope."
+                      },
+                      {
+                        "description": "Denies the write_file command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:deny-write-file",
+                        "markdownDescription": "Denies the write_file command without any pre-configured scope."
+                      },
+                      {
+                        "description": "Denies the write_text_file command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:deny-write-text-file",
+                        "markdownDescription": "Denies the write_text_file command without any pre-configured scope."
+                      },
+                      {
+                        "description": "This enables all read related commands without any pre-configured accessible paths.",
+                        "type": "string",
+                        "const": "fs:read-all",
+                        "markdownDescription": "This enables all read related commands without any pre-configured accessible paths."
+                      },
+                      {
+                        "description": "This permission allows recursive read functionality on the application\nspecific base directories. \n",
+                        "type": "string",
+                        "const": "fs:read-app-specific-dirs-recursive",
+                        "markdownDescription": "This permission allows recursive read functionality on the application\nspecific base directories. \n"
+                      },
+                      {
+                        "description": "This enables directory read and file metadata related commands without any pre-configured accessible paths.",
+                        "type": "string",
+                        "const": "fs:read-dirs",
+                        "markdownDescription": "This enables directory read and file metadata related commands without any pre-configured accessible paths."
+                      },
+                      {
+                        "description": "This enables file read related commands without any pre-configured accessible paths.",
+                        "type": "string",
+                        "const": "fs:read-files",
+                        "markdownDescription": "This enables file read related commands without any pre-configured accessible paths."
+                      },
+                      {
+                        "description": "This enables all index or metadata related commands without any pre-configured accessible paths.",
+                        "type": "string",
+                        "const": "fs:read-meta",
+                        "markdownDescription": "This enables all index or metadata related commands without any pre-configured accessible paths."
+                      },
+                      {
+                        "description": "An empty permission you can use to modify the global scope.\n\n## Example\n\n```json\n{\n  \"identifier\": \"read-documents\",\n  \"windows\": [\"main\"],\n  \"permissions\": [\n    \"fs:allow-read\",\n    {\n      \"identifier\": \"fs:scope\",\n      \"allow\": [\n        \"$APPDATA/documents/**/*\"\n      ],\n      \"deny\": [\n        \"$APPDATA/documents/secret.txt\"\n      ]\n    }\n  ]\n}\n```\n",
+                        "type": "string",
+                        "const": "fs:scope",
+                        "markdownDescription": "An empty permission you can use to modify the global scope.\n\n## Example\n\n```json\n{\n  \"identifier\": \"read-documents\",\n  \"windows\": [\"main\"],\n  \"permissions\": [\n    \"fs:allow-read\",\n    {\n      \"identifier\": \"fs:scope\",\n      \"allow\": [\n        \"$APPDATA/documents/**/*\"\n      ],\n      \"deny\": [\n        \"$APPDATA/documents/secret.txt\"\n      ]\n    }\n  ]\n}\n```\n"
+                      },
+                      {
+                        "description": "This scope permits access to all files and list content of top level directories in the application folders.",
+                        "type": "string",
+                        "const": "fs:scope-app",
+                        "markdownDescription": "This scope permits access to all files and list content of top level directories in the application folders."
+                      },
+                      {
+                        "description": "This scope permits to list all files and folders in the application directories.",
+                        "type": "string",
+                        "const": "fs:scope-app-index",
+                        "markdownDescription": "This scope permits to list all files and folders in the application directories."
+                      },
+                      {
+                        "description": "This scope permits recursive access to the complete application folders, including sub directories and files.",
+                        "type": "string",
+                        "const": "fs:scope-app-recursive",
+                        "markdownDescription": "This scope permits recursive access to the complete application folders, including sub directories and files."
+                      },
+                      {
+                        "description": "This scope permits access to all files and list content of top level directories in the `$APPCACHE` folder.",
+                        "type": "string",
+                        "const": "fs:scope-appcache",
+                        "markdownDescription": "This scope permits access to all files and list content of top level directories in the `$APPCACHE` folder."
+                      },
+                      {
+                        "description": "This scope permits to list all files and folders in the `$APPCACHE`folder.",
+                        "type": "string",
+                        "const": "fs:scope-appcache-index",
+                        "markdownDescription": "This scope permits to list all files and folders in the `$APPCACHE`folder."
+                      },
+                      {
+                        "description": "This scope permits recursive access to the complete `$APPCACHE` folder, including sub directories and files.",
+                        "type": "string",
+                        "const": "fs:scope-appcache-recursive",
+                        "markdownDescription": "This scope permits recursive access to the complete `$APPCACHE` folder, including sub directories and files."
+                      },
+                      {
+                        "description": "This scope permits access to all files and list content of top level directories in the `$APPCONFIG` folder.",
+                        "type": "string",
+                        "const": "fs:scope-appconfig",
+                        "markdownDescription": "This scope permits access to all files and list content of top level directories in the `$APPCONFIG` folder."
+                      },
+                      {
+                        "description": "This scope permits to list all files and folders in the `$APPCONFIG`folder.",
+                        "type": "string",
+                        "const": "fs:scope-appconfig-index",
+                        "markdownDescription": "This scope permits to list all files and folders in the `$APPCONFIG`folder."
+                      },
+                      {
+                        "description": "This scope permits recursive access to the complete `$APPCONFIG` folder, including sub directories and files.",
+                        "type": "string",
+                        "const": "fs:scope-appconfig-recursive",
+                        "markdownDescription": "This scope permits recursive access to the complete `$APPCONFIG` folder, including sub directories and files."
+                      },
+                      {
+                        "description": "This scope permits access to all files and list content of top level directories in the `$APPDATA` folder.",
+                        "type": "string",
+                        "const": "fs:scope-appdata",
+                        "markdownDescription": "This scope permits access to all files and list content of top level directories in the `$APPDATA` folder."
+                      },
+                      {
+                        "description": "This scope permits to list all files and folders in the `$APPDATA`folder.",
+                        "type": "string",
+                        "const": "fs:scope-appdata-index",
+                        "markdownDescription": "This scope permits to list all files and folders in the `$APPDATA`folder."
+                      },
+                      {
+                        "description": "This scope permits recursive access to the complete `$APPDATA` folder, including sub directories and files.",
+                        "type": "string",
+                        "const": "fs:scope-appdata-recursive",
+                        "markdownDescription": "This scope permits recursive access to the complete `$APPDATA` folder, including sub directories and files."
+                      },
+                      {
+                        "description": "This scope permits access to all files and list content of top level directories in the `$APPLOCALDATA` folder.",
+                        "type": "string",
+                        "const": "fs:scope-applocaldata",
+                        "markdownDescription": "This scope permits access to all files and list content of top level directories in the `$APPLOCALDATA` folder."
+                      },
+                      {
+                        "description": "This scope permits to list all files and folders in the `$APPLOCALDATA`folder.",
+                        "type": "string",
+                        "const": "fs:scope-applocaldata-index",
+                        "markdownDescription": "This scope permits to list all files and folders in the `$APPLOCALDATA`folder."
+                      },
+                      {
+                        "description": "This scope permits recursive access to the complete `$APPLOCALDATA` folder, including sub directories and files.",
+                        "type": "string",
+                        "const": "fs:scope-applocaldata-recursive",
+                        "markdownDescription": "This scope permits recursive access to the complete `$APPLOCALDATA` folder, including sub directories and files."
+                      },
+                      {
+                        "description": "This scope permits access to all files and list content of top level directories in the `$APPLOG` folder.",
+                        "type": "string",
+                        "const": "fs:scope-applog",
+                        "markdownDescription": "This scope permits access to all files and list content of top level directories in the `$APPLOG` folder."
+                      },
+                      {
+                        "description": "This scope permits to list all files and folders in the `$APPLOG`folder.",
+                        "type": "string",
+                        "const": "fs:scope-applog-index",
+                        "markdownDescription": "This scope permits to list all files and folders in the `$APPLOG`folder."
+                      },
+                      {
+                        "description": "This scope permits recursive access to the complete `$APPLOG` folder, including sub directories and files.",
+                        "type": "string",
+                        "const": "fs:scope-applog-recursive",
+                        "markdownDescription": "This scope permits recursive access to the complete `$APPLOG` folder, including sub directories and files."
+                      },
+                      {
+                        "description": "This scope permits access to all files and list content of top level directories in the `$AUDIO` folder.",
+                        "type": "string",
+                        "const": "fs:scope-audio",
+                        "markdownDescription": "This scope permits access to all files and list content of top level directories in the `$AUDIO` folder."
+                      },
+                      {
+                        "description": "This scope permits to list all files and folders in the `$AUDIO`folder.",
+                        "type": "string",
+                        "const": "fs:scope-audio-index",
+                        "markdownDescription": "This scope permits to list all files and folders in the `$AUDIO`folder."
+                      },
+                      {
+                        "description": "This scope permits recursive access to the complete `$AUDIO` folder, including sub directories and files.",
+                        "type": "string",
+                        "const": "fs:scope-audio-recursive",
+                        "markdownDescription": "This scope permits recursive access to the complete `$AUDIO` folder, including sub directories and files."
+                      },
+                      {
+                        "description": "This scope permits access to all files and list content of top level directories in the `$CACHE` folder.",
+                        "type": "string",
+                        "const": "fs:scope-cache",
+                        "markdownDescription": "This scope permits access to all files and list content of top level directories in the `$CACHE` folder."
+                      },
+                      {
+                        "description": "This scope permits to list all files and folders in the `$CACHE`folder.",
+                        "type": "string",
+                        "const": "fs:scope-cache-index",
+                        "markdownDescription": "This scope permits to list all files and folders in the `$CACHE`folder."
+                      },
+                      {
+                        "description": "This scope permits recursive access to the complete `$CACHE` folder, including sub directories and files.",
+                        "type": "string",
+                        "const": "fs:scope-cache-recursive",
+                        "markdownDescription": "This scope permits recursive access to the complete `$CACHE` folder, including sub directories and files."
+                      },
+                      {
+                        "description": "This scope permits access to all files and list content of top level directories in the `$CONFIG` folder.",
+                        "type": "string",
+                        "const": "fs:scope-config",
+                        "markdownDescription": "This scope permits access to all files and list content of top level directories in the `$CONFIG` folder."
+                      },
+                      {
+                        "description": "This scope permits to list all files and folders in the `$CONFIG`folder.",
+                        "type": "string",
+                        "const": "fs:scope-config-index",
+                        "markdownDescription": "This scope permits to list all files and folders in the `$CONFIG`folder."
+                      },
+                      {
+                        "description": "This scope permits recursive access to the complete `$CONFIG` folder, including sub directories and files.",
+                        "type": "string",
+                        "const": "fs:scope-config-recursive",
+                        "markdownDescription": "This scope permits recursive access to the complete `$CONFIG` folder, including sub directories and files."
+                      },
+                      {
+                        "description": "This scope permits access to all files and list content of top level directories in the `$DATA` folder.",
+                        "type": "string",
+                        "const": "fs:scope-data",
+                        "markdownDescription": "This scope permits access to all files and list content of top level directories in the `$DATA` folder."
+                      },
+                      {
+                        "description": "This scope permits to list all files and folders in the `$DATA`folder.",
+                        "type": "string",
+                        "const": "fs:scope-data-index",
+                        "markdownDescription": "This scope permits to list all files and folders in the `$DATA`folder."
+                      },
+                      {
+                        "description": "This scope permits recursive access to the complete `$DATA` folder, including sub directories and files.",
+                        "type": "string",
+                        "const": "fs:scope-data-recursive",
+                        "markdownDescription": "This scope permits recursive access to the complete `$DATA` folder, including sub directories and files."
+                      },
+                      {
+                        "description": "This scope permits access to all files and list content of top level directories in the `$DESKTOP` folder.",
+                        "type": "string",
+                        "const": "fs:scope-desktop",
+                        "markdownDescription": "This scope permits access to all files and list content of top level directories in the `$DESKTOP` folder."
+                      },
+                      {
+                        "description": "This scope permits to list all files and folders in the `$DESKTOP`folder.",
+                        "type": "string",
+                        "const": "fs:scope-desktop-index",
+                        "markdownDescription": "This scope permits to list all files and folders in the `$DESKTOP`folder."
+                      },
+                      {
+                        "description": "This scope permits recursive access to the complete `$DESKTOP` folder, including sub directories and files.",
+                        "type": "string",
+                        "const": "fs:scope-desktop-recursive",
+                        "markdownDescription": "This scope permits recursive access to the complete `$DESKTOP` folder, including sub directories and files."
+                      },
+                      {
+                        "description": "This scope permits access to all files and list content of top level directories in the `$DOCUMENT` folder.",
+                        "type": "string",
+                        "const": "fs:scope-document",
+                        "markdownDescription": "This scope permits access to all files and list content of top level directories in the `$DOCUMENT` folder."
+                      },
+                      {
+                        "description": "This scope permits to list all files and folders in the `$DOCUMENT`folder.",
+                        "type": "string",
+                        "const": "fs:scope-document-index",
+                        "markdownDescription": "This scope permits to list all files and folders in the `$DOCUMENT`folder."
+                      },
+                      {
+                        "description": "This scope permits recursive access to the complete `$DOCUMENT` folder, including sub directories and files.",
+                        "type": "string",
+                        "const": "fs:scope-document-recursive",
+                        "markdownDescription": "This scope permits recursive access to the complete `$DOCUMENT` folder, including sub directories and files."
+                      },
+                      {
+                        "description": "This scope permits access to all files and list content of top level directories in the `$DOWNLOAD` folder.",
+                        "type": "string",
+                        "const": "fs:scope-download",
+                        "markdownDescription": "This scope permits access to all files and list content of top level directories in the `$DOWNLOAD` folder."
+                      },
+                      {
+                        "description": "This scope permits to list all files and folders in the `$DOWNLOAD`folder.",
+                        "type": "string",
+                        "const": "fs:scope-download-index",
+                        "markdownDescription": "This scope permits to list all files and folders in the `$DOWNLOAD`folder."
+                      },
+                      {
+                        "description": "This scope permits recursive access to the complete `$DOWNLOAD` folder, including sub directories and files.",
+                        "type": "string",
+                        "const": "fs:scope-download-recursive",
+                        "markdownDescription": "This scope permits recursive access to the complete `$DOWNLOAD` folder, including sub directories and files."
+                      },
+                      {
+                        "description": "This scope permits access to all files and list content of top level directories in the `$EXE` folder.",
+                        "type": "string",
+                        "const": "fs:scope-exe",
+                        "markdownDescription": "This scope permits access to all files and list content of top level directories in the `$EXE` folder."
+                      },
+                      {
+                        "description": "This scope permits to list all files and folders in the `$EXE`folder.",
+                        "type": "string",
+                        "const": "fs:scope-exe-index",
+                        "markdownDescription": "This scope permits to list all files and folders in the `$EXE`folder."
+                      },
+                      {
+                        "description": "This scope permits recursive access to the complete `$EXE` folder, including sub directories and files.",
+                        "type": "string",
+                        "const": "fs:scope-exe-recursive",
+                        "markdownDescription": "This scope permits recursive access to the complete `$EXE` folder, including sub directories and files."
+                      },
+                      {
+                        "description": "This scope permits access to all files and list content of top level directories in the `$FONT` folder.",
+                        "type": "string",
+                        "const": "fs:scope-font",
+                        "markdownDescription": "This scope permits access to all files and list content of top level directories in the `$FONT` folder."
+                      },
+                      {
+                        "description": "This scope permits to list all files and folders in the `$FONT`folder.",
+                        "type": "string",
+                        "const": "fs:scope-font-index",
+                        "markdownDescription": "This scope permits to list all files and folders in the `$FONT`folder."
+                      },
+                      {
+                        "description": "This scope permits recursive access to the complete `$FONT` folder, including sub directories and files.",
+                        "type": "string",
+                        "const": "fs:scope-font-recursive",
+                        "markdownDescription": "This scope permits recursive access to the complete `$FONT` folder, including sub directories and files."
+                      },
+                      {
+                        "description": "This scope permits access to all files and list content of top level directories in the `$HOME` folder.",
+                        "type": "string",
+                        "const": "fs:scope-home",
+                        "markdownDescription": "This scope permits access to all files and list content of top level directories in the `$HOME` folder."
+                      },
+                      {
+                        "description": "This scope permits to list all files and folders in the `$HOME`folder.",
+                        "type": "string",
+                        "const": "fs:scope-home-index",
+                        "markdownDescription": "This scope permits to list all files and folders in the `$HOME`folder."
+                      },
+                      {
+                        "description": "This scope permits recursive access to the complete `$HOME` folder, including sub directories and files.",
+                        "type": "string",
+                        "const": "fs:scope-home-recursive",
+                        "markdownDescription": "This scope permits recursive access to the complete `$HOME` folder, including sub directories and files."
+                      },
+                      {
+                        "description": "This scope permits access to all files and list content of top level directories in the `$LOCALDATA` folder.",
+                        "type": "string",
+                        "const": "fs:scope-localdata",
+                        "markdownDescription": "This scope permits access to all files and list content of top level directories in the `$LOCALDATA` folder."
+                      },
+                      {
+                        "description": "This scope permits to list all files and folders in the `$LOCALDATA`folder.",
+                        "type": "string",
+                        "const": "fs:scope-localdata-index",
+                        "markdownDescription": "This scope permits to list all files and folders in the `$LOCALDATA`folder."
+                      },
+                      {
+                        "description": "This scope permits recursive access to the complete `$LOCALDATA` folder, including sub directories and files.",
+                        "type": "string",
+                        "const": "fs:scope-localdata-recursive",
+                        "markdownDescription": "This scope permits recursive access to the complete `$LOCALDATA` folder, including sub directories and files."
+                      },
+                      {
+                        "description": "This scope permits access to all files and list content of top level directories in the `$LOG` folder.",
+                        "type": "string",
+                        "const": "fs:scope-log",
+                        "markdownDescription": "This scope permits access to all files and list content of top level directories in the `$LOG` folder."
+                      },
+                      {
+                        "description": "This scope permits to list all files and folders in the `$LOG`folder.",
+                        "type": "string",
+                        "const": "fs:scope-log-index",
+                        "markdownDescription": "This scope permits to list all files and folders in the `$LOG`folder."
+                      },
+                      {
+                        "description": "This scope permits recursive access to the complete `$LOG` folder, including sub directories and files.",
+                        "type": "string",
+                        "const": "fs:scope-log-recursive",
+                        "markdownDescription": "This scope permits recursive access to the complete `$LOG` folder, including sub directories and files."
+                      },
+                      {
+                        "description": "This scope permits access to all files and list content of top level directories in the `$PICTURE` folder.",
+                        "type": "string",
+                        "const": "fs:scope-picture",
+                        "markdownDescription": "This scope permits access to all files and list content of top level directories in the `$PICTURE` folder."
+                      },
+                      {
+                        "description": "This scope permits to list all files and folders in the `$PICTURE`folder.",
+                        "type": "string",
+                        "const": "fs:scope-picture-index",
+                        "markdownDescription": "This scope permits to list all files and folders in the `$PICTURE`folder."
+                      },
+                      {
+                        "description": "This scope permits recursive access to the complete `$PICTURE` folder, including sub directories and files.",
+                        "type": "string",
+                        "const": "fs:scope-picture-recursive",
+                        "markdownDescription": "This scope permits recursive access to the complete `$PICTURE` folder, including sub directories and files."
+                      },
+                      {
+                        "description": "This scope permits access to all files and list content of top level directories in the `$PUBLIC` folder.",
+                        "type": "string",
+                        "const": "fs:scope-public",
+                        "markdownDescription": "This scope permits access to all files and list content of top level directories in the `$PUBLIC` folder."
+                      },
+                      {
+                        "description": "This scope permits to list all files and folders in the `$PUBLIC`folder.",
+                        "type": "string",
+                        "const": "fs:scope-public-index",
+                        "markdownDescription": "This scope permits to list all files and folders in the `$PUBLIC`folder."
+                      },
+                      {
+                        "description": "This scope permits recursive access to the complete `$PUBLIC` folder, including sub directories and files.",
+                        "type": "string",
+                        "const": "fs:scope-public-recursive",
+                        "markdownDescription": "This scope permits recursive access to the complete `$PUBLIC` folder, including sub directories and files."
+                      },
+                      {
+                        "description": "This scope permits access to all files and list content of top level directories in the `$RESOURCE` folder.",
+                        "type": "string",
+                        "const": "fs:scope-resource",
+                        "markdownDescription": "This scope permits access to all files and list content of top level directories in the `$RESOURCE` folder."
+                      },
+                      {
+                        "description": "This scope permits to list all files and folders in the `$RESOURCE`folder.",
+                        "type": "string",
+                        "const": "fs:scope-resource-index",
+                        "markdownDescription": "This scope permits to list all files and folders in the `$RESOURCE`folder."
+                      },
+                      {
+                        "description": "This scope permits recursive access to the complete `$RESOURCE` folder, including sub directories and files.",
+                        "type": "string",
+                        "const": "fs:scope-resource-recursive",
+                        "markdownDescription": "This scope permits recursive access to the complete `$RESOURCE` folder, including sub directories and files."
+                      },
+                      {
+                        "description": "This scope permits access to all files and list content of top level directories in the `$RUNTIME` folder.",
+                        "type": "string",
+                        "const": "fs:scope-runtime",
+                        "markdownDescription": "This scope permits access to all files and list content of top level directories in the `$RUNTIME` folder."
+                      },
+                      {
+                        "description": "This scope permits to list all files and folders in the `$RUNTIME`folder.",
+                        "type": "string",
+                        "const": "fs:scope-runtime-index",
+                        "markdownDescription": "This scope permits to list all files and folders in the `$RUNTIME`folder."
+                      },
+                      {
+                        "description": "This scope permits recursive access to the complete `$RUNTIME` folder, including sub directories and files.",
+                        "type": "string",
+                        "const": "fs:scope-runtime-recursive",
+                        "markdownDescription": "This scope permits recursive access to the complete `$RUNTIME` folder, including sub directories and files."
+                      },
+                      {
+                        "description": "This scope permits access to all files and list content of top level directories in the `$TEMP` folder.",
+                        "type": "string",
+                        "const": "fs:scope-temp",
+                        "markdownDescription": "This scope permits access to all files and list content of top level directories in the `$TEMP` folder."
+                      },
+                      {
+                        "description": "This scope permits to list all files and folders in the `$TEMP`folder.",
+                        "type": "string",
+                        "const": "fs:scope-temp-index",
+                        "markdownDescription": "This scope permits to list all files and folders in the `$TEMP`folder."
+                      },
+                      {
+                        "description": "This scope permits recursive access to the complete `$TEMP` folder, including sub directories and files.",
+                        "type": "string",
+                        "const": "fs:scope-temp-recursive",
+                        "markdownDescription": "This scope permits recursive access to the complete `$TEMP` folder, including sub directories and files."
+                      },
+                      {
+                        "description": "This scope permits access to all files and list content of top level directories in the `$TEMPLATE` folder.",
+                        "type": "string",
+                        "const": "fs:scope-template",
+                        "markdownDescription": "This scope permits access to all files and list content of top level directories in the `$TEMPLATE` folder."
+                      },
+                      {
+                        "description": "This scope permits to list all files and folders in the `$TEMPLATE`folder.",
+                        "type": "string",
+                        "const": "fs:scope-template-index",
+                        "markdownDescription": "This scope permits to list all files and folders in the `$TEMPLATE`folder."
+                      },
+                      {
+                        "description": "This scope permits recursive access to the complete `$TEMPLATE` folder, including sub directories and files.",
+                        "type": "string",
+                        "const": "fs:scope-template-recursive",
+                        "markdownDescription": "This scope permits recursive access to the complete `$TEMPLATE` folder, including sub directories and files."
+                      },
+                      {
+                        "description": "This scope permits access to all files and list content of top level directories in the `$VIDEO` folder.",
+                        "type": "string",
+                        "const": "fs:scope-video",
+                        "markdownDescription": "This scope permits access to all files and list content of top level directories in the `$VIDEO` folder."
+                      },
+                      {
+                        "description": "This scope permits to list all files and folders in the `$VIDEO`folder.",
+                        "type": "string",
+                        "const": "fs:scope-video-index",
+                        "markdownDescription": "This scope permits to list all files and folders in the `$VIDEO`folder."
+                      },
+                      {
+                        "description": "This scope permits recursive access to the complete `$VIDEO` folder, including sub directories and files.",
+                        "type": "string",
+                        "const": "fs:scope-video-recursive",
+                        "markdownDescription": "This scope permits recursive access to the complete `$VIDEO` folder, including sub directories and files."
+                      },
+                      {
+                        "description": "This enables all write related commands without any pre-configured accessible paths.",
+                        "type": "string",
+                        "const": "fs:write-all",
+                        "markdownDescription": "This enables all write related commands without any pre-configured accessible paths."
+                      },
+                      {
+                        "description": "This enables all file write related commands without any pre-configured accessible paths.",
+                        "type": "string",
+                        "const": "fs:write-files",
+                        "markdownDescription": "This enables all file write related commands without any pre-configured accessible paths."
+                      }
+                    ]
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "allow": {
+                    "items": {
+                      "title": "FsScopeEntry",
+                      "description": "FS scope entry.",
+                      "anyOf": [
+                        {
+                          "description": "A path that can be accessed by the webview when using the fs APIs. FS scope path pattern.\n\nThe pattern can start with a variable that resolves to a system base directory. The variables are: `$AUDIO`, `$CACHE`, `$CONFIG`, `$DATA`, `$LOCALDATA`, `$DESKTOP`, `$DOCUMENT`, `$DOWNLOAD`, `$EXE`, `$FONT`, `$HOME`, `$PICTURE`, `$PUBLIC`, `$RUNTIME`, `$TEMPLATE`, `$VIDEO`, `$RESOURCE`, `$APP`, `$LOG`, `$TEMP`, `$APPCONFIG`, `$APPDATA`, `$APPLOCALDATA`, `$APPCACHE`, `$APPLOG`.",
+                          "type": "string"
+                        },
+                        {
+                          "type": "object",
+                          "required": [
+                            "path"
+                          ],
+                          "properties": {
+                            "path": {
+                              "description": "A path that can be accessed by the webview when using the fs APIs.\n\nThe pattern can start with a variable that resolves to a system base directory. The variables are: `$AUDIO`, `$CACHE`, `$CONFIG`, `$DATA`, `$LOCALDATA`, `$DESKTOP`, `$DOCUMENT`, `$DOWNLOAD`, `$EXE`, `$FONT`, `$HOME`, `$PICTURE`, `$PUBLIC`, `$RUNTIME`, `$TEMPLATE`, `$VIDEO`, `$RESOURCE`, `$APP`, `$LOG`, `$TEMP`, `$APPCONFIG`, `$APPDATA`, `$APPLOCALDATA`, `$APPCACHE`, `$APPLOG`.",
+                              "type": "string"
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "deny": {
+                    "items": {
+                      "title": "FsScopeEntry",
+                      "description": "FS scope entry.",
+                      "anyOf": [
+                        {
+                          "description": "A path that can be accessed by the webview when using the fs APIs. FS scope path pattern.\n\nThe pattern can start with a variable that resolves to a system base directory. The variables are: `$AUDIO`, `$CACHE`, `$CONFIG`, `$DATA`, `$LOCALDATA`, `$DESKTOP`, `$DOCUMENT`, `$DOWNLOAD`, `$EXE`, `$FONT`, `$HOME`, `$PICTURE`, `$PUBLIC`, `$RUNTIME`, `$TEMPLATE`, `$VIDEO`, `$RESOURCE`, `$APP`, `$LOG`, `$TEMP`, `$APPCONFIG`, `$APPDATA`, `$APPLOCALDATA`, `$APPCACHE`, `$APPLOG`.",
+                          "type": "string"
+                        },
+                        {
+                          "type": "object",
+                          "required": [
+                            "path"
+                          ],
+                          "properties": {
+                            "path": {
+                              "description": "A path that can be accessed by the webview when using the fs APIs.\n\nThe pattern can start with a variable that resolves to a system base directory. The variables are: `$AUDIO`, `$CACHE`, `$CONFIG`, `$DATA`, `$LOCALDATA`, `$DESKTOP`, `$DOCUMENT`, `$DOWNLOAD`, `$EXE`, `$FONT`, `$HOME`, `$PICTURE`, `$PUBLIC`, `$RUNTIME`, `$TEMPLATE`, `$VIDEO`, `$RESOURCE`, `$APP`, `$LOG`, `$TEMP`, `$APPCONFIG`, `$APPDATA`, `$APPLOCALDATA`, `$APPCACHE`, `$APPLOG`.",
+                              "type": "string"
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              },
+              "properties": {
+                "identifier": {
+                  "description": "Identifier of the permission or permission set.",
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/Identifier"
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "identifier": {
+                    "anyOf": [
+                      {
+                        "description": "This permission set configures which\nshell functionality is exposed by default.\n\n#### Granted Permissions\n\nIt allows to use the `open` functionality with a reasonable\nscope pre-configured. It will allow opening `http(s)://`,\n`tel:` and `mailto:` links.\n\n#### This default permission set includes:\n\n- `allow-open`",
+                        "type": "string",
+                        "const": "shell:default",
+                        "markdownDescription": "This permission set configures which\nshell functionality is exposed by default.\n\n#### Granted Permissions\n\nIt allows to use the `open` functionality with a reasonable\nscope pre-configured. It will allow opening `http(s)://`,\n`tel:` and `mailto:` links.\n\n#### This default permission set includes:\n\n- `allow-open`"
+                      },
+                      {
+                        "description": "Enables the execute command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "shell:allow-execute",
+                        "markdownDescription": "Enables the execute command without any pre-configured scope."
+                      },
+                      {
+                        "description": "Enables the kill command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "shell:allow-kill",
+                        "markdownDescription": "Enables the kill command without any pre-configured scope."
+                      },
+                      {
+                        "description": "Enables the open command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "shell:allow-open",
+                        "markdownDescription": "Enables the open command without any pre-configured scope."
+                      },
+                      {
+                        "description": "Enables the spawn command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "shell:allow-spawn",
+                        "markdownDescription": "Enables the spawn command without any pre-configured scope."
+                      },
+                      {
+                        "description": "Enables the stdin_write command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "shell:allow-stdin-write",
+                        "markdownDescription": "Enables the stdin_write command without any pre-configured scope."
+                      },
+                      {
+                        "description": "Denies the execute command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "shell:deny-execute",
+                        "markdownDescription": "Denies the execute command without any pre-configured scope."
+                      },
+                      {
+                        "description": "Denies the kill command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "shell:deny-kill",
+                        "markdownDescription": "Denies the kill command without any pre-configured scope."
+                      },
+                      {
+                        "description": "Denies the open command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "shell:deny-open",
+                        "markdownDescription": "Denies the open command without any pre-configured scope."
+                      },
+                      {
+                        "description": "Denies the spawn command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "shell:deny-spawn",
+                        "markdownDescription": "Denies the spawn command without any pre-configured scope."
+                      },
+                      {
+                        "description": "Denies the stdin_write command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "shell:deny-stdin-write",
+                        "markdownDescription": "Denies the stdin_write command without any pre-configured scope."
+                      }
+                    ]
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "allow": {
+                    "items": {
+                      "title": "ShellScopeEntry",
+                      "description": "Shell scope entry.",
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "required": [
+                            "cmd",
+                            "name"
+                          ],
+                          "properties": {
+                            "args": {
+                              "description": "The allowed arguments for the command execution.",
+                              "allOf": [
+                                {
+                                  "$ref": "#/definitions/ShellScopeEntryAllowedArgs"
+                                }
+                              ]
+                            },
+                            "cmd": {
+                              "description": "The command name. It can start with a variable that resolves to a system base directory. The variables are: `$AUDIO`, `$CACHE`, `$CONFIG`, `$DATA`, `$LOCALDATA`, `$DESKTOP`, `$DOCUMENT`, `$DOWNLOAD`, `$EXE`, `$FONT`, `$HOME`, `$PICTURE`, `$PUBLIC`, `$RUNTIME`, `$TEMPLATE`, `$VIDEO`, `$RESOURCE`, `$LOG`, `$TEMP`, `$APPCONFIG`, `$APPDATA`, `$APPLOCALDATA`, `$APPCACHE`, `$APPLOG`.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "The name for this allowed shell command configuration.\n\nThis name will be used inside of the webview API to call this command along with any specified arguments.",
+                              "type": "string"
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "required": [
+                            "name",
+                            "sidecar"
+                          ],
+                          "properties": {
+                            "args": {
+                              "description": "The allowed arguments for the command execution.",
+                              "allOf": [
+                                {
+                                  "$ref": "#/definitions/ShellScopeEntryAllowedArgs"
+                                }
+                              ]
+                            },
+                            "name": {
+                              "description": "The name for this allowed shell command configuration.\n\nThis name will be used inside of the webview API to call this command along with any specified arguments.",
+                              "type": "string"
+                            },
+                            "sidecar": {
+                              "description": "If this command is a sidecar command.",
+                              "type": "boolean"
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      ]
+                    }
+                  },
+                  "deny": {
+                    "items": {
+                      "title": "ShellScopeEntry",
+                      "description": "Shell scope entry.",
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "required": [
+                            "cmd",
+                            "name"
+                          ],
+                          "properties": {
+                            "args": {
+                              "description": "The allowed arguments for the command execution.",
+                              "allOf": [
+                                {
+                                  "$ref": "#/definitions/ShellScopeEntryAllowedArgs"
+                                }
+                              ]
+                            },
+                            "cmd": {
+                              "description": "The command name. It can start with a variable that resolves to a system base directory. The variables are: `$AUDIO`, `$CACHE`, `$CONFIG`, `$DATA`, `$LOCALDATA`, `$DESKTOP`, `$DOCUMENT`, `$DOWNLOAD`, `$EXE`, `$FONT`, `$HOME`, `$PICTURE`, `$PUBLIC`, `$RUNTIME`, `$TEMPLATE`, `$VIDEO`, `$RESOURCE`, `$LOG`, `$TEMP`, `$APPCONFIG`, `$APPDATA`, `$APPLOCALDATA`, `$APPCACHE`, `$APPLOG`.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "The name for this allowed shell command configuration.\n\nThis name will be used inside of the webview API to call this command along with any specified arguments.",
+                              "type": "string"
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "required": [
+                            "name",
+                            "sidecar"
+                          ],
+                          "properties": {
+                            "args": {
+                              "description": "The allowed arguments for the command execution.",
+                              "allOf": [
+                                {
+                                  "$ref": "#/definitions/ShellScopeEntryAllowedArgs"
+                                }
+                              ]
+                            },
+                            "name": {
+                              "description": "The name for this allowed shell command configuration.\n\nThis name will be used inside of the webview API to call this command along with any specified arguments.",
+                              "type": "string"
+                            },
+                            "sidecar": {
+                              "description": "If this command is a sidecar command.",
+                              "type": "boolean"
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      ]
+                    }
+                  }
+                }
+              },
+              "properties": {
+                "identifier": {
+                  "description": "Identifier of the permission or permission set.",
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/Identifier"
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "properties": {
+                "identifier": {
+                  "description": "Identifier of the permission or permission set.",
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/Identifier"
+                    }
+                  ]
+                },
+                "allow": {
+                  "description": "Data that defines what is allowed by the scope.",
+                  "type": [
+                    "array",
+                    "null"
+                  ],
+                  "items": {
+                    "$ref": "#/definitions/Value"
+                  }
+                },
+                "deny": {
+                  "description": "Data that defines what is denied by the scope. This should be prioritized by validation logic.",
+                  "type": [
+                    "array",
+                    "null"
+                  ],
+                  "items": {
+                    "$ref": "#/definitions/Value"
+                  }
+                }
+              }
+            }
+          ],
+          "required": [
+            "identifier"
+          ]
+        }
+      ]
+    },
+    "Identifier": {
+      "description": "Permission identifier",
+      "oneOf": [
+        {
+          "description": "This permission set configures if your\napplication can enable or disable auto\nstarting the application on boot.\n\n#### Granted Permissions\n\nIt allows all to check, enable and\ndisable the automatic start on boot.\n\n\n#### This default permission set includes:\n\n- `allow-enable`\n- `allow-disable`\n- `allow-is-enabled`",
+          "type": "string",
+          "const": "autostart:default",
+          "markdownDescription": "This permission set configures if your\napplication can enable or disable auto\nstarting the application on boot.\n\n#### Granted Permissions\n\nIt allows all to check, enable and\ndisable the automatic start on boot.\n\n\n#### This default permission set includes:\n\n- `allow-enable`\n- `allow-disable`\n- `allow-is-enabled`"
+        },
+        {
+          "description": "Enables the disable command without any pre-configured scope.",
+          "type": "string",
+          "const": "autostart:allow-disable",
+          "markdownDescription": "Enables the disable command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the enable command without any pre-configured scope.",
+          "type": "string",
+          "const": "autostart:allow-enable",
+          "markdownDescription": "Enables the enable command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the is_enabled command without any pre-configured scope.",
+          "type": "string",
+          "const": "autostart:allow-is-enabled",
+          "markdownDescription": "Enables the is_enabled command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the disable command without any pre-configured scope.",
+          "type": "string",
+          "const": "autostart:deny-disable",
+          "markdownDescription": "Denies the disable command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the enable command without any pre-configured scope.",
+          "type": "string",
+          "const": "autostart:deny-enable",
+          "markdownDescription": "Denies the enable command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the is_enabled command without any pre-configured scope.",
+          "type": "string",
+          "const": "autostart:deny-is-enabled",
+          "markdownDescription": "Denies the is_enabled command without any pre-configured scope."
+        },
+        {
+          "description": "Default core plugins set.\n#### This default permission set includes:\n\n- `core:path:default`\n- `core:event:default`\n- `core:window:default`\n- `core:webview:default`\n- `core:app:default`\n- `core:image:default`\n- `core:resources:default`\n- `core:menu:default`\n- `core:tray:default`",
+          "type": "string",
+          "const": "core:default",
+          "markdownDescription": "Default core plugins set.\n#### This default permission set includes:\n\n- `core:path:default`\n- `core:event:default`\n- `core:window:default`\n- `core:webview:default`\n- `core:app:default`\n- `core:image:default`\n- `core:resources:default`\n- `core:menu:default`\n- `core:tray:default`"
+        },
+        {
+          "description": "Default permissions for the plugin.\n#### This default permission set includes:\n\n- `allow-version`\n- `allow-name`\n- `allow-tauri-version`\n- `allow-identifier`\n- `allow-bundle-type`\n- `allow-register-listener`\n- `allow-remove-listener`",
+          "type": "string",
+          "const": "core:app:default",
+          "markdownDescription": "Default permissions for the plugin.\n#### This default permission set includes:\n\n- `allow-version`\n- `allow-name`\n- `allow-tauri-version`\n- `allow-identifier`\n- `allow-bundle-type`\n- `allow-register-listener`\n- `allow-remove-listener`"
+        },
+        {
+          "description": "Enables the app_hide command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:allow-app-hide",
+          "markdownDescription": "Enables the app_hide command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the app_show command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:allow-app-show",
+          "markdownDescription": "Enables the app_show command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the bundle_type command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:allow-bundle-type",
+          "markdownDescription": "Enables the bundle_type command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the default_window_icon command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:allow-default-window-icon",
+          "markdownDescription": "Enables the default_window_icon command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the fetch_data_store_identifiers command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:allow-fetch-data-store-identifiers",
+          "markdownDescription": "Enables the fetch_data_store_identifiers command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the identifier command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:allow-identifier",
+          "markdownDescription": "Enables the identifier command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the name command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:allow-name",
+          "markdownDescription": "Enables the name command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the register_listener command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:allow-register-listener",
+          "markdownDescription": "Enables the register_listener command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the remove_data_store command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:allow-remove-data-store",
+          "markdownDescription": "Enables the remove_data_store command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the remove_listener command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:allow-remove-listener",
+          "markdownDescription": "Enables the remove_listener command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_app_theme command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:allow-set-app-theme",
+          "markdownDescription": "Enables the set_app_theme command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_dock_visibility command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:allow-set-dock-visibility",
+          "markdownDescription": "Enables the set_dock_visibility command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the tauri_version command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:allow-tauri-version",
+          "markdownDescription": "Enables the tauri_version command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the version command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:allow-version",
+          "markdownDescription": "Enables the version command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the app_hide command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:deny-app-hide",
+          "markdownDescription": "Denies the app_hide command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the app_show command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:deny-app-show",
+          "markdownDescription": "Denies the app_show command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the bundle_type command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:deny-bundle-type",
+          "markdownDescription": "Denies the bundle_type command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the default_window_icon command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:deny-default-window-icon",
+          "markdownDescription": "Denies the default_window_icon command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the fetch_data_store_identifiers command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:deny-fetch-data-store-identifiers",
+          "markdownDescription": "Denies the fetch_data_store_identifiers command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the identifier command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:deny-identifier",
+          "markdownDescription": "Denies the identifier command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the name command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:deny-name",
+          "markdownDescription": "Denies the name command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the register_listener command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:deny-register-listener",
+          "markdownDescription": "Denies the register_listener command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the remove_data_store command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:deny-remove-data-store",
+          "markdownDescription": "Denies the remove_data_store command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the remove_listener command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:deny-remove-listener",
+          "markdownDescription": "Denies the remove_listener command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_app_theme command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:deny-set-app-theme",
+          "markdownDescription": "Denies the set_app_theme command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_dock_visibility command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:deny-set-dock-visibility",
+          "markdownDescription": "Denies the set_dock_visibility command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the tauri_version command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:deny-tauri-version",
+          "markdownDescription": "Denies the tauri_version command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the version command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:deny-version",
+          "markdownDescription": "Denies the version command without any pre-configured scope."
+        },
+        {
+          "description": "Default permissions for the plugin, which enables all commands.\n#### This default permission set includes:\n\n- `allow-listen`\n- `allow-unlisten`\n- `allow-emit`\n- `allow-emit-to`",
+          "type": "string",
+          "const": "core:event:default",
+          "markdownDescription": "Default permissions for the plugin, which enables all commands.\n#### This default permission set includes:\n\n- `allow-listen`\n- `allow-unlisten`\n- `allow-emit`\n- `allow-emit-to`"
+        },
+        {
+          "description": "Enables the emit command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:event:allow-emit",
+          "markdownDescription": "Enables the emit command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the emit_to command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:event:allow-emit-to",
+          "markdownDescription": "Enables the emit_to command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the listen command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:event:allow-listen",
+          "markdownDescription": "Enables the listen command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the unlisten command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:event:allow-unlisten",
+          "markdownDescription": "Enables the unlisten command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the emit command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:event:deny-emit",
+          "markdownDescription": "Denies the emit command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the emit_to command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:event:deny-emit-to",
+          "markdownDescription": "Denies the emit_to command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the listen command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:event:deny-listen",
+          "markdownDescription": "Denies the listen command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the unlisten command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:event:deny-unlisten",
+          "markdownDescription": "Denies the unlisten command without any pre-configured scope."
+        },
+        {
+          "description": "Default permissions for the plugin, which enables all commands.\n#### This default permission set includes:\n\n- `allow-new`\n- `allow-from-bytes`\n- `allow-from-path`\n- `allow-rgba`\n- `allow-size`",
+          "type": "string",
+          "const": "core:image:default",
+          "markdownDescription": "Default permissions for the plugin, which enables all commands.\n#### This default permission set includes:\n\n- `allow-new`\n- `allow-from-bytes`\n- `allow-from-path`\n- `allow-rgba`\n- `allow-size`"
+        },
+        {
+          "description": "Enables the from_bytes command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:image:allow-from-bytes",
+          "markdownDescription": "Enables the from_bytes command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the from_path command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:image:allow-from-path",
+          "markdownDescription": "Enables the from_path command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the new command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:image:allow-new",
+          "markdownDescription": "Enables the new command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the rgba command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:image:allow-rgba",
+          "markdownDescription": "Enables the rgba command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the size command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:image:allow-size",
+          "markdownDescription": "Enables the size command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the from_bytes command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:image:deny-from-bytes",
+          "markdownDescription": "Denies the from_bytes command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the from_path command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:image:deny-from-path",
+          "markdownDescription": "Denies the from_path command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the new command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:image:deny-new",
+          "markdownDescription": "Denies the new command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the rgba command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:image:deny-rgba",
+          "markdownDescription": "Denies the rgba command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the size command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:image:deny-size",
+          "markdownDescription": "Denies the size command without any pre-configured scope."
+        },
+        {
+          "description": "Default permissions for the plugin, which enables all commands.\n#### This default permission set includes:\n\n- `allow-new`\n- `allow-append`\n- `allow-prepend`\n- `allow-insert`\n- `allow-remove`\n- `allow-remove-at`\n- `allow-items`\n- `allow-get`\n- `allow-popup`\n- `allow-create-default`\n- `allow-set-as-app-menu`\n- `allow-set-as-window-menu`\n- `allow-text`\n- `allow-set-text`\n- `allow-is-enabled`\n- `allow-set-enabled`\n- `allow-set-accelerator`\n- `allow-set-as-windows-menu-for-nsapp`\n- `allow-set-as-help-menu-for-nsapp`\n- `allow-is-checked`\n- `allow-set-checked`\n- `allow-set-icon`",
+          "type": "string",
+          "const": "core:menu:default",
+          "markdownDescription": "Default permissions for the plugin, which enables all commands.\n#### This default permission set includes:\n\n- `allow-new`\n- `allow-append`\n- `allow-prepend`\n- `allow-insert`\n- `allow-remove`\n- `allow-remove-at`\n- `allow-items`\n- `allow-get`\n- `allow-popup`\n- `allow-create-default`\n- `allow-set-as-app-menu`\n- `allow-set-as-window-menu`\n- `allow-text`\n- `allow-set-text`\n- `allow-is-enabled`\n- `allow-set-enabled`\n- `allow-set-accelerator`\n- `allow-set-as-windows-menu-for-nsapp`\n- `allow-set-as-help-menu-for-nsapp`\n- `allow-is-checked`\n- `allow-set-checked`\n- `allow-set-icon`"
+        },
+        {
+          "description": "Enables the append command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:allow-append",
+          "markdownDescription": "Enables the append command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the create_default command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:allow-create-default",
+          "markdownDescription": "Enables the create_default command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the get command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:allow-get",
+          "markdownDescription": "Enables the get command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the insert command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:allow-insert",
+          "markdownDescription": "Enables the insert command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the is_checked command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:allow-is-checked",
+          "markdownDescription": "Enables the is_checked command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the is_enabled command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:allow-is-enabled",
+          "markdownDescription": "Enables the is_enabled command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the items command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:allow-items",
+          "markdownDescription": "Enables the items command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the new command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:allow-new",
+          "markdownDescription": "Enables the new command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the popup command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:allow-popup",
+          "markdownDescription": "Enables the popup command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the prepend command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:allow-prepend",
+          "markdownDescription": "Enables the prepend command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the remove command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:allow-remove",
+          "markdownDescription": "Enables the remove command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the remove_at command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:allow-remove-at",
+          "markdownDescription": "Enables the remove_at command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_accelerator command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:allow-set-accelerator",
+          "markdownDescription": "Enables the set_accelerator command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_as_app_menu command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:allow-set-as-app-menu",
+          "markdownDescription": "Enables the set_as_app_menu command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_as_help_menu_for_nsapp command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:allow-set-as-help-menu-for-nsapp",
+          "markdownDescription": "Enables the set_as_help_menu_for_nsapp command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_as_window_menu command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:allow-set-as-window-menu",
+          "markdownDescription": "Enables the set_as_window_menu command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_as_windows_menu_for_nsapp command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:allow-set-as-windows-menu-for-nsapp",
+          "markdownDescription": "Enables the set_as_windows_menu_for_nsapp command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_checked command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:allow-set-checked",
+          "markdownDescription": "Enables the set_checked command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_enabled command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:allow-set-enabled",
+          "markdownDescription": "Enables the set_enabled command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_icon command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:allow-set-icon",
+          "markdownDescription": "Enables the set_icon command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_text command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:allow-set-text",
+          "markdownDescription": "Enables the set_text command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the text command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:allow-text",
+          "markdownDescription": "Enables the text command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the append command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:deny-append",
+          "markdownDescription": "Denies the append command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the create_default command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:deny-create-default",
+          "markdownDescription": "Denies the create_default command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the get command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:deny-get",
+          "markdownDescription": "Denies the get command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the insert command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:deny-insert",
+          "markdownDescription": "Denies the insert command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the is_checked command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:deny-is-checked",
+          "markdownDescription": "Denies the is_checked command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the is_enabled command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:deny-is-enabled",
+          "markdownDescription": "Denies the is_enabled command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the items command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:deny-items",
+          "markdownDescription": "Denies the items command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the new command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:deny-new",
+          "markdownDescription": "Denies the new command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the popup command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:deny-popup",
+          "markdownDescription": "Denies the popup command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the prepend command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:deny-prepend",
+          "markdownDescription": "Denies the prepend command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the remove command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:deny-remove",
+          "markdownDescription": "Denies the remove command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the remove_at command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:deny-remove-at",
+          "markdownDescription": "Denies the remove_at command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_accelerator command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:deny-set-accelerator",
+          "markdownDescription": "Denies the set_accelerator command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_as_app_menu command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:deny-set-as-app-menu",
+          "markdownDescription": "Denies the set_as_app_menu command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_as_help_menu_for_nsapp command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:deny-set-as-help-menu-for-nsapp",
+          "markdownDescription": "Denies the set_as_help_menu_for_nsapp command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_as_window_menu command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:deny-set-as-window-menu",
+          "markdownDescription": "Denies the set_as_window_menu command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_as_windows_menu_for_nsapp command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:deny-set-as-windows-menu-for-nsapp",
+          "markdownDescription": "Denies the set_as_windows_menu_for_nsapp command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_checked command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:deny-set-checked",
+          "markdownDescription": "Denies the set_checked command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_enabled command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:deny-set-enabled",
+          "markdownDescription": "Denies the set_enabled command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_icon command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:deny-set-icon",
+          "markdownDescription": "Denies the set_icon command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_text command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:deny-set-text",
+          "markdownDescription": "Denies the set_text command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the text command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:deny-text",
+          "markdownDescription": "Denies the text command without any pre-configured scope."
+        },
+        {
+          "description": "Default permissions for the plugin, which enables all commands.\n#### This default permission set includes:\n\n- `allow-resolve-directory`\n- `allow-resolve`\n- `allow-normalize`\n- `allow-join`\n- `allow-dirname`\n- `allow-extname`\n- `allow-basename`\n- `allow-is-absolute`",
+          "type": "string",
+          "const": "core:path:default",
+          "markdownDescription": "Default permissions for the plugin, which enables all commands.\n#### This default permission set includes:\n\n- `allow-resolve-directory`\n- `allow-resolve`\n- `allow-normalize`\n- `allow-join`\n- `allow-dirname`\n- `allow-extname`\n- `allow-basename`\n- `allow-is-absolute`"
+        },
+        {
+          "description": "Enables the basename command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:path:allow-basename",
+          "markdownDescription": "Enables the basename command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the dirname command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:path:allow-dirname",
+          "markdownDescription": "Enables the dirname command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the extname command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:path:allow-extname",
+          "markdownDescription": "Enables the extname command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the is_absolute command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:path:allow-is-absolute",
+          "markdownDescription": "Enables the is_absolute command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the join command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:path:allow-join",
+          "markdownDescription": "Enables the join command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the normalize command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:path:allow-normalize",
+          "markdownDescription": "Enables the normalize command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the resolve command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:path:allow-resolve",
+          "markdownDescription": "Enables the resolve command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the resolve_directory command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:path:allow-resolve-directory",
+          "markdownDescription": "Enables the resolve_directory command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the basename command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:path:deny-basename",
+          "markdownDescription": "Denies the basename command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the dirname command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:path:deny-dirname",
+          "markdownDescription": "Denies the dirname command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the extname command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:path:deny-extname",
+          "markdownDescription": "Denies the extname command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the is_absolute command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:path:deny-is-absolute",
+          "markdownDescription": "Denies the is_absolute command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the join command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:path:deny-join",
+          "markdownDescription": "Denies the join command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the normalize command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:path:deny-normalize",
+          "markdownDescription": "Denies the normalize command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the resolve command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:path:deny-resolve",
+          "markdownDescription": "Denies the resolve command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the resolve_directory command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:path:deny-resolve-directory",
+          "markdownDescription": "Denies the resolve_directory command without any pre-configured scope."
+        },
+        {
+          "description": "Default permissions for the plugin, which enables all commands.\n#### This default permission set includes:\n\n- `allow-close`",
+          "type": "string",
+          "const": "core:resources:default",
+          "markdownDescription": "Default permissions for the plugin, which enables all commands.\n#### This default permission set includes:\n\n- `allow-close`"
+        },
+        {
+          "description": "Enables the close command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:resources:allow-close",
+          "markdownDescription": "Enables the close command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the close command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:resources:deny-close",
+          "markdownDescription": "Denies the close command without any pre-configured scope."
+        },
+        {
+          "description": "Default permissions for the plugin, which enables all commands.\n#### This default permission set includes:\n\n- `allow-new`\n- `allow-get-by-id`\n- `allow-remove-by-id`\n- `allow-set-icon`\n- `allow-set-menu`\n- `allow-set-tooltip`\n- `allow-set-title`\n- `allow-set-visible`\n- `allow-set-temp-dir-path`\n- `allow-set-icon-as-template`\n- `allow-set-show-menu-on-left-click`",
+          "type": "string",
+          "const": "core:tray:default",
+          "markdownDescription": "Default permissions for the plugin, which enables all commands.\n#### This default permission set includes:\n\n- `allow-new`\n- `allow-get-by-id`\n- `allow-remove-by-id`\n- `allow-set-icon`\n- `allow-set-menu`\n- `allow-set-tooltip`\n- `allow-set-title`\n- `allow-set-visible`\n- `allow-set-temp-dir-path`\n- `allow-set-icon-as-template`\n- `allow-set-show-menu-on-left-click`"
+        },
+        {
+          "description": "Enables the get_by_id command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:allow-get-by-id",
+          "markdownDescription": "Enables the get_by_id command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the new command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:allow-new",
+          "markdownDescription": "Enables the new command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the remove_by_id command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:allow-remove-by-id",
+          "markdownDescription": "Enables the remove_by_id command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_icon command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:allow-set-icon",
+          "markdownDescription": "Enables the set_icon command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_icon_as_template command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:allow-set-icon-as-template",
+          "markdownDescription": "Enables the set_icon_as_template command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_menu command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:allow-set-menu",
+          "markdownDescription": "Enables the set_menu command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_show_menu_on_left_click command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:allow-set-show-menu-on-left-click",
+          "markdownDescription": "Enables the set_show_menu_on_left_click command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_temp_dir_path command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:allow-set-temp-dir-path",
+          "markdownDescription": "Enables the set_temp_dir_path command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_title command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:allow-set-title",
+          "markdownDescription": "Enables the set_title command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_tooltip command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:allow-set-tooltip",
+          "markdownDescription": "Enables the set_tooltip command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_visible command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:allow-set-visible",
+          "markdownDescription": "Enables the set_visible command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the get_by_id command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:deny-get-by-id",
+          "markdownDescription": "Denies the get_by_id command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the new command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:deny-new",
+          "markdownDescription": "Denies the new command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the remove_by_id command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:deny-remove-by-id",
+          "markdownDescription": "Denies the remove_by_id command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_icon command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:deny-set-icon",
+          "markdownDescription": "Denies the set_icon command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_icon_as_template command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:deny-set-icon-as-template",
+          "markdownDescription": "Denies the set_icon_as_template command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_menu command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:deny-set-menu",
+          "markdownDescription": "Denies the set_menu command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_show_menu_on_left_click command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:deny-set-show-menu-on-left-click",
+          "markdownDescription": "Denies the set_show_menu_on_left_click command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_temp_dir_path command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:deny-set-temp-dir-path",
+          "markdownDescription": "Denies the set_temp_dir_path command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_title command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:deny-set-title",
+          "markdownDescription": "Denies the set_title command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_tooltip command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:deny-set-tooltip",
+          "markdownDescription": "Denies the set_tooltip command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_visible command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:deny-set-visible",
+          "markdownDescription": "Denies the set_visible command without any pre-configured scope."
+        },
+        {
+          "description": "Default permissions for the plugin.\n#### This default permission set includes:\n\n- `allow-get-all-webviews`\n- `allow-webview-position`\n- `allow-webview-size`\n- `allow-internal-toggle-devtools`",
+          "type": "string",
+          "const": "core:webview:default",
+          "markdownDescription": "Default permissions for the plugin.\n#### This default permission set includes:\n\n- `allow-get-all-webviews`\n- `allow-webview-position`\n- `allow-webview-size`\n- `allow-internal-toggle-devtools`"
+        },
+        {
+          "description": "Enables the clear_all_browsing_data command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:allow-clear-all-browsing-data",
+          "markdownDescription": "Enables the clear_all_browsing_data command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the create_webview command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:allow-create-webview",
+          "markdownDescription": "Enables the create_webview command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the create_webview_window command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:allow-create-webview-window",
+          "markdownDescription": "Enables the create_webview_window command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the get_all_webviews command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:allow-get-all-webviews",
+          "markdownDescription": "Enables the get_all_webviews command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the internal_toggle_devtools command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:allow-internal-toggle-devtools",
+          "markdownDescription": "Enables the internal_toggle_devtools command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the print command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:allow-print",
+          "markdownDescription": "Enables the print command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the reparent command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:allow-reparent",
+          "markdownDescription": "Enables the reparent command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_webview_auto_resize command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:allow-set-webview-auto-resize",
+          "markdownDescription": "Enables the set_webview_auto_resize command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_webview_background_color command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:allow-set-webview-background-color",
+          "markdownDescription": "Enables the set_webview_background_color command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_webview_focus command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:allow-set-webview-focus",
+          "markdownDescription": "Enables the set_webview_focus command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_webview_position command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:allow-set-webview-position",
+          "markdownDescription": "Enables the set_webview_position command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_webview_size command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:allow-set-webview-size",
+          "markdownDescription": "Enables the set_webview_size command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_webview_zoom command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:allow-set-webview-zoom",
+          "markdownDescription": "Enables the set_webview_zoom command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the webview_close command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:allow-webview-close",
+          "markdownDescription": "Enables the webview_close command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the webview_hide command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:allow-webview-hide",
+          "markdownDescription": "Enables the webview_hide command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the webview_position command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:allow-webview-position",
+          "markdownDescription": "Enables the webview_position command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the webview_show command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:allow-webview-show",
+          "markdownDescription": "Enables the webview_show command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the webview_size command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:allow-webview-size",
+          "markdownDescription": "Enables the webview_size command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the clear_all_browsing_data command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:deny-clear-all-browsing-data",
+          "markdownDescription": "Denies the clear_all_browsing_data command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the create_webview command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:deny-create-webview",
+          "markdownDescription": "Denies the create_webview command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the create_webview_window command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:deny-create-webview-window",
+          "markdownDescription": "Denies the create_webview_window command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the get_all_webviews command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:deny-get-all-webviews",
+          "markdownDescription": "Denies the get_all_webviews command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the internal_toggle_devtools command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:deny-internal-toggle-devtools",
+          "markdownDescription": "Denies the internal_toggle_devtools command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the print command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:deny-print",
+          "markdownDescription": "Denies the print command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the reparent command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:deny-reparent",
+          "markdownDescription": "Denies the reparent command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_webview_auto_resize command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:deny-set-webview-auto-resize",
+          "markdownDescription": "Denies the set_webview_auto_resize command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_webview_background_color command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:deny-set-webview-background-color",
+          "markdownDescription": "Denies the set_webview_background_color command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_webview_focus command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:deny-set-webview-focus",
+          "markdownDescription": "Denies the set_webview_focus command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_webview_position command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:deny-set-webview-position",
+          "markdownDescription": "Denies the set_webview_position command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_webview_size command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:deny-set-webview-size",
+          "markdownDescription": "Denies the set_webview_size command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_webview_zoom command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:deny-set-webview-zoom",
+          "markdownDescription": "Denies the set_webview_zoom command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the webview_close command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:deny-webview-close",
+          "markdownDescription": "Denies the webview_close command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the webview_hide command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:deny-webview-hide",
+          "markdownDescription": "Denies the webview_hide command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the webview_position command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:deny-webview-position",
+          "markdownDescription": "Denies the webview_position command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the webview_show command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:deny-webview-show",
+          "markdownDescription": "Denies the webview_show command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the webview_size command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:deny-webview-size",
+          "markdownDescription": "Denies the webview_size command without any pre-configured scope."
+        },
+        {
+          "description": "Default permissions for the plugin.\n#### This default permission set includes:\n\n- `allow-get-all-windows`\n- `allow-scale-factor`\n- `allow-inner-position`\n- `allow-outer-position`\n- `allow-inner-size`\n- `allow-outer-size`\n- `allow-is-fullscreen`\n- `allow-is-minimized`\n- `allow-is-maximized`\n- `allow-is-focused`\n- `allow-is-decorated`\n- `allow-is-resizable`\n- `allow-is-maximizable`\n- `allow-is-minimizable`\n- `allow-is-closable`\n- `allow-is-visible`\n- `allow-is-enabled`\n- `allow-title`\n- `allow-current-monitor`\n- `allow-primary-monitor`\n- `allow-monitor-from-point`\n- `allow-available-monitors`\n- `allow-cursor-position`\n- `allow-theme`\n- `allow-is-always-on-top`\n- `allow-internal-toggle-maximize`",
+          "type": "string",
+          "const": "core:window:default",
+          "markdownDescription": "Default permissions for the plugin.\n#### This default permission set includes:\n\n- `allow-get-all-windows`\n- `allow-scale-factor`\n- `allow-inner-position`\n- `allow-outer-position`\n- `allow-inner-size`\n- `allow-outer-size`\n- `allow-is-fullscreen`\n- `allow-is-minimized`\n- `allow-is-maximized`\n- `allow-is-focused`\n- `allow-is-decorated`\n- `allow-is-resizable`\n- `allow-is-maximizable`\n- `allow-is-minimizable`\n- `allow-is-closable`\n- `allow-is-visible`\n- `allow-is-enabled`\n- `allow-title`\n- `allow-current-monitor`\n- `allow-primary-monitor`\n- `allow-monitor-from-point`\n- `allow-available-monitors`\n- `allow-cursor-position`\n- `allow-theme`\n- `allow-is-always-on-top`\n- `allow-internal-toggle-maximize`"
+        },
+        {
+          "description": "Enables the available_monitors command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-available-monitors",
+          "markdownDescription": "Enables the available_monitors command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the center command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-center",
+          "markdownDescription": "Enables the center command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the close command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-close",
+          "markdownDescription": "Enables the close command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the create command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-create",
+          "markdownDescription": "Enables the create command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the current_monitor command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-current-monitor",
+          "markdownDescription": "Enables the current_monitor command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the cursor_position command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-cursor-position",
+          "markdownDescription": "Enables the cursor_position command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the destroy command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-destroy",
+          "markdownDescription": "Enables the destroy command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the get_all_windows command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-get-all-windows",
+          "markdownDescription": "Enables the get_all_windows command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the hide command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-hide",
+          "markdownDescription": "Enables the hide command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the inner_position command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-inner-position",
+          "markdownDescription": "Enables the inner_position command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the inner_size command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-inner-size",
+          "markdownDescription": "Enables the inner_size command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the internal_toggle_maximize command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-internal-toggle-maximize",
+          "markdownDescription": "Enables the internal_toggle_maximize command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the is_always_on_top command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-is-always-on-top",
+          "markdownDescription": "Enables the is_always_on_top command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the is_closable command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-is-closable",
+          "markdownDescription": "Enables the is_closable command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the is_decorated command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-is-decorated",
+          "markdownDescription": "Enables the is_decorated command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the is_enabled command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-is-enabled",
+          "markdownDescription": "Enables the is_enabled command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the is_focused command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-is-focused",
+          "markdownDescription": "Enables the is_focused command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the is_fullscreen command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-is-fullscreen",
+          "markdownDescription": "Enables the is_fullscreen command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the is_maximizable command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-is-maximizable",
+          "markdownDescription": "Enables the is_maximizable command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the is_maximized command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-is-maximized",
+          "markdownDescription": "Enables the is_maximized command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the is_minimizable command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-is-minimizable",
+          "markdownDescription": "Enables the is_minimizable command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the is_minimized command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-is-minimized",
+          "markdownDescription": "Enables the is_minimized command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the is_resizable command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-is-resizable",
+          "markdownDescription": "Enables the is_resizable command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the is_visible command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-is-visible",
+          "markdownDescription": "Enables the is_visible command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the maximize command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-maximize",
+          "markdownDescription": "Enables the maximize command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the minimize command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-minimize",
+          "markdownDescription": "Enables the minimize command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the monitor_from_point command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-monitor-from-point",
+          "markdownDescription": "Enables the monitor_from_point command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the outer_position command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-outer-position",
+          "markdownDescription": "Enables the outer_position command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the outer_size command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-outer-size",
+          "markdownDescription": "Enables the outer_size command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the primary_monitor command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-primary-monitor",
+          "markdownDescription": "Enables the primary_monitor command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the request_user_attention command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-request-user-attention",
+          "markdownDescription": "Enables the request_user_attention command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the scale_factor command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-scale-factor",
+          "markdownDescription": "Enables the scale_factor command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_always_on_bottom command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-always-on-bottom",
+          "markdownDescription": "Enables the set_always_on_bottom command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_always_on_top command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-always-on-top",
+          "markdownDescription": "Enables the set_always_on_top command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_background_color command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-background-color",
+          "markdownDescription": "Enables the set_background_color command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_badge_count command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-badge-count",
+          "markdownDescription": "Enables the set_badge_count command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_badge_label command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-badge-label",
+          "markdownDescription": "Enables the set_badge_label command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_closable command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-closable",
+          "markdownDescription": "Enables the set_closable command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_content_protected command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-content-protected",
+          "markdownDescription": "Enables the set_content_protected command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_cursor_grab command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-cursor-grab",
+          "markdownDescription": "Enables the set_cursor_grab command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_cursor_icon command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-cursor-icon",
+          "markdownDescription": "Enables the set_cursor_icon command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_cursor_position command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-cursor-position",
+          "markdownDescription": "Enables the set_cursor_position command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_cursor_visible command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-cursor-visible",
+          "markdownDescription": "Enables the set_cursor_visible command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_decorations command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-decorations",
+          "markdownDescription": "Enables the set_decorations command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_effects command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-effects",
+          "markdownDescription": "Enables the set_effects command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_enabled command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-enabled",
+          "markdownDescription": "Enables the set_enabled command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_focus command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-focus",
+          "markdownDescription": "Enables the set_focus command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_focusable command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-focusable",
+          "markdownDescription": "Enables the set_focusable command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_fullscreen command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-fullscreen",
+          "markdownDescription": "Enables the set_fullscreen command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_icon command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-icon",
+          "markdownDescription": "Enables the set_icon command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_ignore_cursor_events command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-ignore-cursor-events",
+          "markdownDescription": "Enables the set_ignore_cursor_events command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_max_size command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-max-size",
+          "markdownDescription": "Enables the set_max_size command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_maximizable command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-maximizable",
+          "markdownDescription": "Enables the set_maximizable command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_min_size command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-min-size",
+          "markdownDescription": "Enables the set_min_size command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_minimizable command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-minimizable",
+          "markdownDescription": "Enables the set_minimizable command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_overlay_icon command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-overlay-icon",
+          "markdownDescription": "Enables the set_overlay_icon command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_position command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-position",
+          "markdownDescription": "Enables the set_position command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_progress_bar command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-progress-bar",
+          "markdownDescription": "Enables the set_progress_bar command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_resizable command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-resizable",
+          "markdownDescription": "Enables the set_resizable command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_shadow command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-shadow",
+          "markdownDescription": "Enables the set_shadow command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_simple_fullscreen command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-simple-fullscreen",
+          "markdownDescription": "Enables the set_simple_fullscreen command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_size command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-size",
+          "markdownDescription": "Enables the set_size command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_size_constraints command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-size-constraints",
+          "markdownDescription": "Enables the set_size_constraints command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_skip_taskbar command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-skip-taskbar",
+          "markdownDescription": "Enables the set_skip_taskbar command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_theme command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-theme",
+          "markdownDescription": "Enables the set_theme command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_title command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-title",
+          "markdownDescription": "Enables the set_title command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_title_bar_style command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-title-bar-style",
+          "markdownDescription": "Enables the set_title_bar_style command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_visible_on_all_workspaces command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-visible-on-all-workspaces",
+          "markdownDescription": "Enables the set_visible_on_all_workspaces command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the show command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-show",
+          "markdownDescription": "Enables the show command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the start_dragging command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-start-dragging",
+          "markdownDescription": "Enables the start_dragging command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the start_resize_dragging command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-start-resize-dragging",
+          "markdownDescription": "Enables the start_resize_dragging command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the theme command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-theme",
+          "markdownDescription": "Enables the theme command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the title command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-title",
+          "markdownDescription": "Enables the title command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the toggle_maximize command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-toggle-maximize",
+          "markdownDescription": "Enables the toggle_maximize command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the unmaximize command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-unmaximize",
+          "markdownDescription": "Enables the unmaximize command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the unminimize command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-unminimize",
+          "markdownDescription": "Enables the unminimize command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the available_monitors command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-available-monitors",
+          "markdownDescription": "Denies the available_monitors command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the center command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-center",
+          "markdownDescription": "Denies the center command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the close command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-close",
+          "markdownDescription": "Denies the close command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the create command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-create",
+          "markdownDescription": "Denies the create command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the current_monitor command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-current-monitor",
+          "markdownDescription": "Denies the current_monitor command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the cursor_position command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-cursor-position",
+          "markdownDescription": "Denies the cursor_position command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the destroy command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-destroy",
+          "markdownDescription": "Denies the destroy command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the get_all_windows command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-get-all-windows",
+          "markdownDescription": "Denies the get_all_windows command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the hide command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-hide",
+          "markdownDescription": "Denies the hide command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the inner_position command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-inner-position",
+          "markdownDescription": "Denies the inner_position command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the inner_size command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-inner-size",
+          "markdownDescription": "Denies the inner_size command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the internal_toggle_maximize command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-internal-toggle-maximize",
+          "markdownDescription": "Denies the internal_toggle_maximize command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the is_always_on_top command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-is-always-on-top",
+          "markdownDescription": "Denies the is_always_on_top command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the is_closable command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-is-closable",
+          "markdownDescription": "Denies the is_closable command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the is_decorated command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-is-decorated",
+          "markdownDescription": "Denies the is_decorated command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the is_enabled command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-is-enabled",
+          "markdownDescription": "Denies the is_enabled command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the is_focused command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-is-focused",
+          "markdownDescription": "Denies the is_focused command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the is_fullscreen command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-is-fullscreen",
+          "markdownDescription": "Denies the is_fullscreen command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the is_maximizable command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-is-maximizable",
+          "markdownDescription": "Denies the is_maximizable command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the is_maximized command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-is-maximized",
+          "markdownDescription": "Denies the is_maximized command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the is_minimizable command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-is-minimizable",
+          "markdownDescription": "Denies the is_minimizable command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the is_minimized command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-is-minimized",
+          "markdownDescription": "Denies the is_minimized command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the is_resizable command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-is-resizable",
+          "markdownDescription": "Denies the is_resizable command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the is_visible command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-is-visible",
+          "markdownDescription": "Denies the is_visible command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the maximize command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-maximize",
+          "markdownDescription": "Denies the maximize command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the minimize command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-minimize",
+          "markdownDescription": "Denies the minimize command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the monitor_from_point command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-monitor-from-point",
+          "markdownDescription": "Denies the monitor_from_point command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the outer_position command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-outer-position",
+          "markdownDescription": "Denies the outer_position command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the outer_size command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-outer-size",
+          "markdownDescription": "Denies the outer_size command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the primary_monitor command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-primary-monitor",
+          "markdownDescription": "Denies the primary_monitor command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the request_user_attention command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-request-user-attention",
+          "markdownDescription": "Denies the request_user_attention command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the scale_factor command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-scale-factor",
+          "markdownDescription": "Denies the scale_factor command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_always_on_bottom command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-always-on-bottom",
+          "markdownDescription": "Denies the set_always_on_bottom command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_always_on_top command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-always-on-top",
+          "markdownDescription": "Denies the set_always_on_top command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_background_color command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-background-color",
+          "markdownDescription": "Denies the set_background_color command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_badge_count command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-badge-count",
+          "markdownDescription": "Denies the set_badge_count command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_badge_label command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-badge-label",
+          "markdownDescription": "Denies the set_badge_label command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_closable command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-closable",
+          "markdownDescription": "Denies the set_closable command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_content_protected command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-content-protected",
+          "markdownDescription": "Denies the set_content_protected command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_cursor_grab command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-cursor-grab",
+          "markdownDescription": "Denies the set_cursor_grab command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_cursor_icon command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-cursor-icon",
+          "markdownDescription": "Denies the set_cursor_icon command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_cursor_position command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-cursor-position",
+          "markdownDescription": "Denies the set_cursor_position command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_cursor_visible command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-cursor-visible",
+          "markdownDescription": "Denies the set_cursor_visible command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_decorations command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-decorations",
+          "markdownDescription": "Denies the set_decorations command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_effects command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-effects",
+          "markdownDescription": "Denies the set_effects command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_enabled command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-enabled",
+          "markdownDescription": "Denies the set_enabled command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_focus command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-focus",
+          "markdownDescription": "Denies the set_focus command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_focusable command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-focusable",
+          "markdownDescription": "Denies the set_focusable command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_fullscreen command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-fullscreen",
+          "markdownDescription": "Denies the set_fullscreen command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_icon command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-icon",
+          "markdownDescription": "Denies the set_icon command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_ignore_cursor_events command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-ignore-cursor-events",
+          "markdownDescription": "Denies the set_ignore_cursor_events command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_max_size command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-max-size",
+          "markdownDescription": "Denies the set_max_size command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_maximizable command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-maximizable",
+          "markdownDescription": "Denies the set_maximizable command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_min_size command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-min-size",
+          "markdownDescription": "Denies the set_min_size command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_minimizable command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-minimizable",
+          "markdownDescription": "Denies the set_minimizable command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_overlay_icon command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-overlay-icon",
+          "markdownDescription": "Denies the set_overlay_icon command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_position command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-position",
+          "markdownDescription": "Denies the set_position command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_progress_bar command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-progress-bar",
+          "markdownDescription": "Denies the set_progress_bar command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_resizable command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-resizable",
+          "markdownDescription": "Denies the set_resizable command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_shadow command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-shadow",
+          "markdownDescription": "Denies the set_shadow command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_simple_fullscreen command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-simple-fullscreen",
+          "markdownDescription": "Denies the set_simple_fullscreen command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_size command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-size",
+          "markdownDescription": "Denies the set_size command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_size_constraints command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-size-constraints",
+          "markdownDescription": "Denies the set_size_constraints command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_skip_taskbar command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-skip-taskbar",
+          "markdownDescription": "Denies the set_skip_taskbar command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_theme command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-theme",
+          "markdownDescription": "Denies the set_theme command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_title command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-title",
+          "markdownDescription": "Denies the set_title command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_title_bar_style command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-title-bar-style",
+          "markdownDescription": "Denies the set_title_bar_style command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_visible_on_all_workspaces command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-visible-on-all-workspaces",
+          "markdownDescription": "Denies the set_visible_on_all_workspaces command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the show command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-show",
+          "markdownDescription": "Denies the show command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the start_dragging command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-start-dragging",
+          "markdownDescription": "Denies the start_dragging command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the start_resize_dragging command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-start-resize-dragging",
+          "markdownDescription": "Denies the start_resize_dragging command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the theme command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-theme",
+          "markdownDescription": "Denies the theme command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the title command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-title",
+          "markdownDescription": "Denies the title command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the toggle_maximize command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-toggle-maximize",
+          "markdownDescription": "Denies the toggle_maximize command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the unmaximize command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-unmaximize",
+          "markdownDescription": "Denies the unmaximize command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the unminimize command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-unminimize",
+          "markdownDescription": "Denies the unminimize command without any pre-configured scope."
+        },
+        {
+          "description": "Allows reading the opened deep link via the get_current command\n#### This default permission set includes:\n\n- `allow-get-current`",
+          "type": "string",
+          "const": "deep-link:default",
+          "markdownDescription": "Allows reading the opened deep link via the get_current command\n#### This default permission set includes:\n\n- `allow-get-current`"
+        },
+        {
+          "description": "Enables the get_current command without any pre-configured scope.",
+          "type": "string",
+          "const": "deep-link:allow-get-current",
+          "markdownDescription": "Enables the get_current command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the is_registered command without any pre-configured scope.",
+          "type": "string",
+          "const": "deep-link:allow-is-registered",
+          "markdownDescription": "Enables the is_registered command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the register command without any pre-configured scope.",
+          "type": "string",
+          "const": "deep-link:allow-register",
+          "markdownDescription": "Enables the register command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the unregister command without any pre-configured scope.",
+          "type": "string",
+          "const": "deep-link:allow-unregister",
+          "markdownDescription": "Enables the unregister command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the get_current command without any pre-configured scope.",
+          "type": "string",
+          "const": "deep-link:deny-get-current",
+          "markdownDescription": "Denies the get_current command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the is_registered command without any pre-configured scope.",
+          "type": "string",
+          "const": "deep-link:deny-is-registered",
+          "markdownDescription": "Denies the is_registered command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the register command without any pre-configured scope.",
+          "type": "string",
+          "const": "deep-link:deny-register",
+          "markdownDescription": "Denies the register command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the unregister command without any pre-configured scope.",
+          "type": "string",
+          "const": "deep-link:deny-unregister",
+          "markdownDescription": "Denies the unregister command without any pre-configured scope."
+        },
+        {
+          "description": "This permission set configures the types of dialogs\navailable from the dialog plugin.\n\n#### Granted Permissions\n\nAll dialog types are enabled.\n\n\n\n#### This default permission set includes:\n\n- `allow-message`\n- `allow-save`\n- `allow-open`",
+          "type": "string",
+          "const": "dialog:default",
+          "markdownDescription": "This permission set configures the types of dialogs\navailable from the dialog plugin.\n\n#### Granted Permissions\n\nAll dialog types are enabled.\n\n\n\n#### This default permission set includes:\n\n- `allow-message`\n- `allow-save`\n- `allow-open`"
+        },
+        {
+          "description": "Enables the ask command without any pre-configured scope. (**DEPRECATED**: This is now an alias to `allow-message` and will be removed in v3)",
+          "type": "string",
+          "const": "dialog:allow-ask",
+          "markdownDescription": "Enables the ask command without any pre-configured scope. (**DEPRECATED**: This is now an alias to `allow-message` and will be removed in v3)"
+        },
+        {
+          "description": "Enables the confirm command without any pre-configured scope. (**DEPRECATED**: This is now an alias to `allow-message` and will be removed in v3)",
+          "type": "string",
+          "const": "dialog:allow-confirm",
+          "markdownDescription": "Enables the confirm command without any pre-configured scope. (**DEPRECATED**: This is now an alias to `allow-message` and will be removed in v3)"
+        },
+        {
+          "description": "Enables the message command without any pre-configured scope.",
+          "type": "string",
+          "const": "dialog:allow-message",
+          "markdownDescription": "Enables the message command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the open command without any pre-configured scope.",
+          "type": "string",
+          "const": "dialog:allow-open",
+          "markdownDescription": "Enables the open command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the save command without any pre-configured scope.",
+          "type": "string",
+          "const": "dialog:allow-save",
+          "markdownDescription": "Enables the save command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the ask command without any pre-configured scope. (**DEPRECATED**: This is now an alias to `deny-message` and will be removed in v3)",
+          "type": "string",
+          "const": "dialog:deny-ask",
+          "markdownDescription": "Denies the ask command without any pre-configured scope. (**DEPRECATED**: This is now an alias to `deny-message` and will be removed in v3)"
+        },
+        {
+          "description": "Denies the confirm command without any pre-configured scope. (**DEPRECATED**: This is now an alias to `deny-message` and will be removed in v3)",
+          "type": "string",
+          "const": "dialog:deny-confirm",
+          "markdownDescription": "Denies the confirm command without any pre-configured scope. (**DEPRECATED**: This is now an alias to `deny-message` and will be removed in v3)"
+        },
+        {
+          "description": "Denies the message command without any pre-configured scope.",
+          "type": "string",
+          "const": "dialog:deny-message",
+          "markdownDescription": "Denies the message command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the open command without any pre-configured scope.",
+          "type": "string",
+          "const": "dialog:deny-open",
+          "markdownDescription": "Denies the open command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the save command without any pre-configured scope.",
+          "type": "string",
+          "const": "dialog:deny-save",
+          "markdownDescription": "Denies the save command without any pre-configured scope."
+        },
+        {
+          "description": "This set of permissions describes the what kind of\nfile system access the `fs` plugin has enabled or denied by default.\n\n#### Granted Permissions\n\nThis default permission set enables read access to the\napplication specific directories (AppConfig, AppData, AppLocalData, AppCache,\nAppLog) and all files and sub directories created in it.\nThe location of these directories depends on the operating system,\nwhere the application is run.\n\nIn general these directories need to be manually created\nby the application at runtime, before accessing files or folders\nin it is possible.\n\nTherefore, it is also allowed to create all of these folders via\nthe `mkdir` command.\n\n#### Denied Permissions\n\nThis default permission set prevents access to critical components\nof the Tauri application by default.\nOn Windows the webview data folder access is denied.\n\n#### This default permission set includes:\n\n- `create-app-specific-dirs`\n- `read-app-specific-dirs-recursive`\n- `deny-default`",
+          "type": "string",
+          "const": "fs:default",
+          "markdownDescription": "This set of permissions describes the what kind of\nfile system access the `fs` plugin has enabled or denied by default.\n\n#### Granted Permissions\n\nThis default permission set enables read access to the\napplication specific directories (AppConfig, AppData, AppLocalData, AppCache,\nAppLog) and all files and sub directories created in it.\nThe location of these directories depends on the operating system,\nwhere the application is run.\n\nIn general these directories need to be manually created\nby the application at runtime, before accessing files or folders\nin it is possible.\n\nTherefore, it is also allowed to create all of these folders via\nthe `mkdir` command.\n\n#### Denied Permissions\n\nThis default permission set prevents access to critical components\nof the Tauri application by default.\nOn Windows the webview data folder access is denied.\n\n#### This default permission set includes:\n\n- `create-app-specific-dirs`\n- `read-app-specific-dirs-recursive`\n- `deny-default`"
+        },
+        {
+          "description": "This allows non-recursive read access to metadata of the application folders, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-app-index`",
+          "type": "string",
+          "const": "fs:allow-app-meta",
+          "markdownDescription": "This allows non-recursive read access to metadata of the application folders, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-app-index`"
+        },
+        {
+          "description": "This allows full recursive read access to metadata of the application folders, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-app-recursive`",
+          "type": "string",
+          "const": "fs:allow-app-meta-recursive",
+          "markdownDescription": "This allows full recursive read access to metadata of the application folders, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-app-recursive`"
+        },
+        {
+          "description": "This allows non-recursive read access to the application folders.\n#### This permission set includes:\n\n- `read-all`\n- `scope-app`",
+          "type": "string",
+          "const": "fs:allow-app-read",
+          "markdownDescription": "This allows non-recursive read access to the application folders.\n#### This permission set includes:\n\n- `read-all`\n- `scope-app`"
+        },
+        {
+          "description": "This allows full recursive read access to the complete application folders, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-app-recursive`",
+          "type": "string",
+          "const": "fs:allow-app-read-recursive",
+          "markdownDescription": "This allows full recursive read access to the complete application folders, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-app-recursive`"
+        },
+        {
+          "description": "This allows non-recursive write access to the application folders.\n#### This permission set includes:\n\n- `write-all`\n- `scope-app`",
+          "type": "string",
+          "const": "fs:allow-app-write",
+          "markdownDescription": "This allows non-recursive write access to the application folders.\n#### This permission set includes:\n\n- `write-all`\n- `scope-app`"
+        },
+        {
+          "description": "This allows full recursive write access to the complete application folders, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-app-recursive`",
+          "type": "string",
+          "const": "fs:allow-app-write-recursive",
+          "markdownDescription": "This allows full recursive write access to the complete application folders, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-app-recursive`"
+        },
+        {
+          "description": "This allows non-recursive read access to metadata of the `$APPCACHE` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-appcache-index`",
+          "type": "string",
+          "const": "fs:allow-appcache-meta",
+          "markdownDescription": "This allows non-recursive read access to metadata of the `$APPCACHE` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-appcache-index`"
+        },
+        {
+          "description": "This allows full recursive read access to metadata of the `$APPCACHE` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-appcache-recursive`",
+          "type": "string",
+          "const": "fs:allow-appcache-meta-recursive",
+          "markdownDescription": "This allows full recursive read access to metadata of the `$APPCACHE` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-appcache-recursive`"
+        },
+        {
+          "description": "This allows non-recursive read access to the `$APPCACHE` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-appcache`",
+          "type": "string",
+          "const": "fs:allow-appcache-read",
+          "markdownDescription": "This allows non-recursive read access to the `$APPCACHE` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-appcache`"
+        },
+        {
+          "description": "This allows full recursive read access to the complete `$APPCACHE` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-appcache-recursive`",
+          "type": "string",
+          "const": "fs:allow-appcache-read-recursive",
+          "markdownDescription": "This allows full recursive read access to the complete `$APPCACHE` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-appcache-recursive`"
+        },
+        {
+          "description": "This allows non-recursive write access to the `$APPCACHE` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-appcache`",
+          "type": "string",
+          "const": "fs:allow-appcache-write",
+          "markdownDescription": "This allows non-recursive write access to the `$APPCACHE` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-appcache`"
+        },
+        {
+          "description": "This allows full recursive write access to the complete `$APPCACHE` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-appcache-recursive`",
+          "type": "string",
+          "const": "fs:allow-appcache-write-recursive",
+          "markdownDescription": "This allows full recursive write access to the complete `$APPCACHE` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-appcache-recursive`"
+        },
+        {
+          "description": "This allows non-recursive read access to metadata of the `$APPCONFIG` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-appconfig-index`",
+          "type": "string",
+          "const": "fs:allow-appconfig-meta",
+          "markdownDescription": "This allows non-recursive read access to metadata of the `$APPCONFIG` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-appconfig-index`"
+        },
+        {
+          "description": "This allows full recursive read access to metadata of the `$APPCONFIG` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-appconfig-recursive`",
+          "type": "string",
+          "const": "fs:allow-appconfig-meta-recursive",
+          "markdownDescription": "This allows full recursive read access to metadata of the `$APPCONFIG` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-appconfig-recursive`"
+        },
+        {
+          "description": "This allows non-recursive read access to the `$APPCONFIG` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-appconfig`",
+          "type": "string",
+          "const": "fs:allow-appconfig-read",
+          "markdownDescription": "This allows non-recursive read access to the `$APPCONFIG` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-appconfig`"
+        },
+        {
+          "description": "This allows full recursive read access to the complete `$APPCONFIG` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-appconfig-recursive`",
+          "type": "string",
+          "const": "fs:allow-appconfig-read-recursive",
+          "markdownDescription": "This allows full recursive read access to the complete `$APPCONFIG` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-appconfig-recursive`"
+        },
+        {
+          "description": "This allows non-recursive write access to the `$APPCONFIG` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-appconfig`",
+          "type": "string",
+          "const": "fs:allow-appconfig-write",
+          "markdownDescription": "This allows non-recursive write access to the `$APPCONFIG` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-appconfig`"
+        },
+        {
+          "description": "This allows full recursive write access to the complete `$APPCONFIG` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-appconfig-recursive`",
+          "type": "string",
+          "const": "fs:allow-appconfig-write-recursive",
+          "markdownDescription": "This allows full recursive write access to the complete `$APPCONFIG` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-appconfig-recursive`"
+        },
+        {
+          "description": "This allows non-recursive read access to metadata of the `$APPDATA` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-appdata-index`",
+          "type": "string",
+          "const": "fs:allow-appdata-meta",
+          "markdownDescription": "This allows non-recursive read access to metadata of the `$APPDATA` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-appdata-index`"
+        },
+        {
+          "description": "This allows full recursive read access to metadata of the `$APPDATA` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-appdata-recursive`",
+          "type": "string",
+          "const": "fs:allow-appdata-meta-recursive",
+          "markdownDescription": "This allows full recursive read access to metadata of the `$APPDATA` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-appdata-recursive`"
+        },
+        {
+          "description": "This allows non-recursive read access to the `$APPDATA` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-appdata`",
+          "type": "string",
+          "const": "fs:allow-appdata-read",
+          "markdownDescription": "This allows non-recursive read access to the `$APPDATA` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-appdata`"
+        },
+        {
+          "description": "This allows full recursive read access to the complete `$APPDATA` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-appdata-recursive`",
+          "type": "string",
+          "const": "fs:allow-appdata-read-recursive",
+          "markdownDescription": "This allows full recursive read access to the complete `$APPDATA` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-appdata-recursive`"
+        },
+        {
+          "description": "This allows non-recursive write access to the `$APPDATA` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-appdata`",
+          "type": "string",
+          "const": "fs:allow-appdata-write",
+          "markdownDescription": "This allows non-recursive write access to the `$APPDATA` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-appdata`"
+        },
+        {
+          "description": "This allows full recursive write access to the complete `$APPDATA` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-appdata-recursive`",
+          "type": "string",
+          "const": "fs:allow-appdata-write-recursive",
+          "markdownDescription": "This allows full recursive write access to the complete `$APPDATA` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-appdata-recursive`"
+        },
+        {
+          "description": "This allows non-recursive read access to metadata of the `$APPLOCALDATA` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-applocaldata-index`",
+          "type": "string",
+          "const": "fs:allow-applocaldata-meta",
+          "markdownDescription": "This allows non-recursive read access to metadata of the `$APPLOCALDATA` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-applocaldata-index`"
+        },
+        {
+          "description": "This allows full recursive read access to metadata of the `$APPLOCALDATA` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-applocaldata-recursive`",
+          "type": "string",
+          "const": "fs:allow-applocaldata-meta-recursive",
+          "markdownDescription": "This allows full recursive read access to metadata of the `$APPLOCALDATA` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-applocaldata-recursive`"
+        },
+        {
+          "description": "This allows non-recursive read access to the `$APPLOCALDATA` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-applocaldata`",
+          "type": "string",
+          "const": "fs:allow-applocaldata-read",
+          "markdownDescription": "This allows non-recursive read access to the `$APPLOCALDATA` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-applocaldata`"
+        },
+        {
+          "description": "This allows full recursive read access to the complete `$APPLOCALDATA` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-applocaldata-recursive`",
+          "type": "string",
+          "const": "fs:allow-applocaldata-read-recursive",
+          "markdownDescription": "This allows full recursive read access to the complete `$APPLOCALDATA` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-applocaldata-recursive`"
+        },
+        {
+          "description": "This allows non-recursive write access to the `$APPLOCALDATA` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-applocaldata`",
+          "type": "string",
+          "const": "fs:allow-applocaldata-write",
+          "markdownDescription": "This allows non-recursive write access to the `$APPLOCALDATA` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-applocaldata`"
+        },
+        {
+          "description": "This allows full recursive write access to the complete `$APPLOCALDATA` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-applocaldata-recursive`",
+          "type": "string",
+          "const": "fs:allow-applocaldata-write-recursive",
+          "markdownDescription": "This allows full recursive write access to the complete `$APPLOCALDATA` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-applocaldata-recursive`"
+        },
+        {
+          "description": "This allows non-recursive read access to metadata of the `$APPLOG` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-applog-index`",
+          "type": "string",
+          "const": "fs:allow-applog-meta",
+          "markdownDescription": "This allows non-recursive read access to metadata of the `$APPLOG` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-applog-index`"
+        },
+        {
+          "description": "This allows full recursive read access to metadata of the `$APPLOG` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-applog-recursive`",
+          "type": "string",
+          "const": "fs:allow-applog-meta-recursive",
+          "markdownDescription": "This allows full recursive read access to metadata of the `$APPLOG` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-applog-recursive`"
+        },
+        {
+          "description": "This allows non-recursive read access to the `$APPLOG` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-applog`",
+          "type": "string",
+          "const": "fs:allow-applog-read",
+          "markdownDescription": "This allows non-recursive read access to the `$APPLOG` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-applog`"
+        },
+        {
+          "description": "This allows full recursive read access to the complete `$APPLOG` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-applog-recursive`",
+          "type": "string",
+          "const": "fs:allow-applog-read-recursive",
+          "markdownDescription": "This allows full recursive read access to the complete `$APPLOG` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-applog-recursive`"
+        },
+        {
+          "description": "This allows non-recursive write access to the `$APPLOG` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-applog`",
+          "type": "string",
+          "const": "fs:allow-applog-write",
+          "markdownDescription": "This allows non-recursive write access to the `$APPLOG` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-applog`"
+        },
+        {
+          "description": "This allows full recursive write access to the complete `$APPLOG` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-applog-recursive`",
+          "type": "string",
+          "const": "fs:allow-applog-write-recursive",
+          "markdownDescription": "This allows full recursive write access to the complete `$APPLOG` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-applog-recursive`"
+        },
+        {
+          "description": "This allows non-recursive read access to metadata of the `$AUDIO` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-audio-index`",
+          "type": "string",
+          "const": "fs:allow-audio-meta",
+          "markdownDescription": "This allows non-recursive read access to metadata of the `$AUDIO` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-audio-index`"
+        },
+        {
+          "description": "This allows full recursive read access to metadata of the `$AUDIO` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-audio-recursive`",
+          "type": "string",
+          "const": "fs:allow-audio-meta-recursive",
+          "markdownDescription": "This allows full recursive read access to metadata of the `$AUDIO` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-audio-recursive`"
+        },
+        {
+          "description": "This allows non-recursive read access to the `$AUDIO` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-audio`",
+          "type": "string",
+          "const": "fs:allow-audio-read",
+          "markdownDescription": "This allows non-recursive read access to the `$AUDIO` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-audio`"
+        },
+        {
+          "description": "This allows full recursive read access to the complete `$AUDIO` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-audio-recursive`",
+          "type": "string",
+          "const": "fs:allow-audio-read-recursive",
+          "markdownDescription": "This allows full recursive read access to the complete `$AUDIO` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-audio-recursive`"
+        },
+        {
+          "description": "This allows non-recursive write access to the `$AUDIO` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-audio`",
+          "type": "string",
+          "const": "fs:allow-audio-write",
+          "markdownDescription": "This allows non-recursive write access to the `$AUDIO` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-audio`"
+        },
+        {
+          "description": "This allows full recursive write access to the complete `$AUDIO` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-audio-recursive`",
+          "type": "string",
+          "const": "fs:allow-audio-write-recursive",
+          "markdownDescription": "This allows full recursive write access to the complete `$AUDIO` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-audio-recursive`"
+        },
+        {
+          "description": "This allows non-recursive read access to metadata of the `$CACHE` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-cache-index`",
+          "type": "string",
+          "const": "fs:allow-cache-meta",
+          "markdownDescription": "This allows non-recursive read access to metadata of the `$CACHE` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-cache-index`"
+        },
+        {
+          "description": "This allows full recursive read access to metadata of the `$CACHE` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-cache-recursive`",
+          "type": "string",
+          "const": "fs:allow-cache-meta-recursive",
+          "markdownDescription": "This allows full recursive read access to metadata of the `$CACHE` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-cache-recursive`"
+        },
+        {
+          "description": "This allows non-recursive read access to the `$CACHE` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-cache`",
+          "type": "string",
+          "const": "fs:allow-cache-read",
+          "markdownDescription": "This allows non-recursive read access to the `$CACHE` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-cache`"
+        },
+        {
+          "description": "This allows full recursive read access to the complete `$CACHE` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-cache-recursive`",
+          "type": "string",
+          "const": "fs:allow-cache-read-recursive",
+          "markdownDescription": "This allows full recursive read access to the complete `$CACHE` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-cache-recursive`"
+        },
+        {
+          "description": "This allows non-recursive write access to the `$CACHE` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-cache`",
+          "type": "string",
+          "const": "fs:allow-cache-write",
+          "markdownDescription": "This allows non-recursive write access to the `$CACHE` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-cache`"
+        },
+        {
+          "description": "This allows full recursive write access to the complete `$CACHE` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-cache-recursive`",
+          "type": "string",
+          "const": "fs:allow-cache-write-recursive",
+          "markdownDescription": "This allows full recursive write access to the complete `$CACHE` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-cache-recursive`"
+        },
+        {
+          "description": "This allows non-recursive read access to metadata of the `$CONFIG` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-config-index`",
+          "type": "string",
+          "const": "fs:allow-config-meta",
+          "markdownDescription": "This allows non-recursive read access to metadata of the `$CONFIG` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-config-index`"
+        },
+        {
+          "description": "This allows full recursive read access to metadata of the `$CONFIG` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-config-recursive`",
+          "type": "string",
+          "const": "fs:allow-config-meta-recursive",
+          "markdownDescription": "This allows full recursive read access to metadata of the `$CONFIG` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-config-recursive`"
+        },
+        {
+          "description": "This allows non-recursive read access to the `$CONFIG` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-config`",
+          "type": "string",
+          "const": "fs:allow-config-read",
+          "markdownDescription": "This allows non-recursive read access to the `$CONFIG` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-config`"
+        },
+        {
+          "description": "This allows full recursive read access to the complete `$CONFIG` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-config-recursive`",
+          "type": "string",
+          "const": "fs:allow-config-read-recursive",
+          "markdownDescription": "This allows full recursive read access to the complete `$CONFIG` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-config-recursive`"
+        },
+        {
+          "description": "This allows non-recursive write access to the `$CONFIG` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-config`",
+          "type": "string",
+          "const": "fs:allow-config-write",
+          "markdownDescription": "This allows non-recursive write access to the `$CONFIG` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-config`"
+        },
+        {
+          "description": "This allows full recursive write access to the complete `$CONFIG` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-config-recursive`",
+          "type": "string",
+          "const": "fs:allow-config-write-recursive",
+          "markdownDescription": "This allows full recursive write access to the complete `$CONFIG` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-config-recursive`"
+        },
+        {
+          "description": "This allows non-recursive read access to metadata of the `$DATA` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-data-index`",
+          "type": "string",
+          "const": "fs:allow-data-meta",
+          "markdownDescription": "This allows non-recursive read access to metadata of the `$DATA` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-data-index`"
+        },
+        {
+          "description": "This allows full recursive read access to metadata of the `$DATA` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-data-recursive`",
+          "type": "string",
+          "const": "fs:allow-data-meta-recursive",
+          "markdownDescription": "This allows full recursive read access to metadata of the `$DATA` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-data-recursive`"
+        },
+        {
+          "description": "This allows non-recursive read access to the `$DATA` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-data`",
+          "type": "string",
+          "const": "fs:allow-data-read",
+          "markdownDescription": "This allows non-recursive read access to the `$DATA` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-data`"
+        },
+        {
+          "description": "This allows full recursive read access to the complete `$DATA` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-data-recursive`",
+          "type": "string",
+          "const": "fs:allow-data-read-recursive",
+          "markdownDescription": "This allows full recursive read access to the complete `$DATA` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-data-recursive`"
+        },
+        {
+          "description": "This allows non-recursive write access to the `$DATA` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-data`",
+          "type": "string",
+          "const": "fs:allow-data-write",
+          "markdownDescription": "This allows non-recursive write access to the `$DATA` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-data`"
+        },
+        {
+          "description": "This allows full recursive write access to the complete `$DATA` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-data-recursive`",
+          "type": "string",
+          "const": "fs:allow-data-write-recursive",
+          "markdownDescription": "This allows full recursive write access to the complete `$DATA` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-data-recursive`"
+        },
+        {
+          "description": "This allows non-recursive read access to metadata of the `$DESKTOP` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-desktop-index`",
+          "type": "string",
+          "const": "fs:allow-desktop-meta",
+          "markdownDescription": "This allows non-recursive read access to metadata of the `$DESKTOP` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-desktop-index`"
+        },
+        {
+          "description": "This allows full recursive read access to metadata of the `$DESKTOP` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-desktop-recursive`",
+          "type": "string",
+          "const": "fs:allow-desktop-meta-recursive",
+          "markdownDescription": "This allows full recursive read access to metadata of the `$DESKTOP` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-desktop-recursive`"
+        },
+        {
+          "description": "This allows non-recursive read access to the `$DESKTOP` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-desktop`",
+          "type": "string",
+          "const": "fs:allow-desktop-read",
+          "markdownDescription": "This allows non-recursive read access to the `$DESKTOP` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-desktop`"
+        },
+        {
+          "description": "This allows full recursive read access to the complete `$DESKTOP` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-desktop-recursive`",
+          "type": "string",
+          "const": "fs:allow-desktop-read-recursive",
+          "markdownDescription": "This allows full recursive read access to the complete `$DESKTOP` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-desktop-recursive`"
+        },
+        {
+          "description": "This allows non-recursive write access to the `$DESKTOP` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-desktop`",
+          "type": "string",
+          "const": "fs:allow-desktop-write",
+          "markdownDescription": "This allows non-recursive write access to the `$DESKTOP` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-desktop`"
+        },
+        {
+          "description": "This allows full recursive write access to the complete `$DESKTOP` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-desktop-recursive`",
+          "type": "string",
+          "const": "fs:allow-desktop-write-recursive",
+          "markdownDescription": "This allows full recursive write access to the complete `$DESKTOP` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-desktop-recursive`"
+        },
+        {
+          "description": "This allows non-recursive read access to metadata of the `$DOCUMENT` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-document-index`",
+          "type": "string",
+          "const": "fs:allow-document-meta",
+          "markdownDescription": "This allows non-recursive read access to metadata of the `$DOCUMENT` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-document-index`"
+        },
+        {
+          "description": "This allows full recursive read access to metadata of the `$DOCUMENT` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-document-recursive`",
+          "type": "string",
+          "const": "fs:allow-document-meta-recursive",
+          "markdownDescription": "This allows full recursive read access to metadata of the `$DOCUMENT` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-document-recursive`"
+        },
+        {
+          "description": "This allows non-recursive read access to the `$DOCUMENT` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-document`",
+          "type": "string",
+          "const": "fs:allow-document-read",
+          "markdownDescription": "This allows non-recursive read access to the `$DOCUMENT` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-document`"
+        },
+        {
+          "description": "This allows full recursive read access to the complete `$DOCUMENT` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-document-recursive`",
+          "type": "string",
+          "const": "fs:allow-document-read-recursive",
+          "markdownDescription": "This allows full recursive read access to the complete `$DOCUMENT` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-document-recursive`"
+        },
+        {
+          "description": "This allows non-recursive write access to the `$DOCUMENT` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-document`",
+          "type": "string",
+          "const": "fs:allow-document-write",
+          "markdownDescription": "This allows non-recursive write access to the `$DOCUMENT` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-document`"
+        },
+        {
+          "description": "This allows full recursive write access to the complete `$DOCUMENT` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-document-recursive`",
+          "type": "string",
+          "const": "fs:allow-document-write-recursive",
+          "markdownDescription": "This allows full recursive write access to the complete `$DOCUMENT` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-document-recursive`"
+        },
+        {
+          "description": "This allows non-recursive read access to metadata of the `$DOWNLOAD` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-download-index`",
+          "type": "string",
+          "const": "fs:allow-download-meta",
+          "markdownDescription": "This allows non-recursive read access to metadata of the `$DOWNLOAD` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-download-index`"
+        },
+        {
+          "description": "This allows full recursive read access to metadata of the `$DOWNLOAD` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-download-recursive`",
+          "type": "string",
+          "const": "fs:allow-download-meta-recursive",
+          "markdownDescription": "This allows full recursive read access to metadata of the `$DOWNLOAD` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-download-recursive`"
+        },
+        {
+          "description": "This allows non-recursive read access to the `$DOWNLOAD` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-download`",
+          "type": "string",
+          "const": "fs:allow-download-read",
+          "markdownDescription": "This allows non-recursive read access to the `$DOWNLOAD` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-download`"
+        },
+        {
+          "description": "This allows full recursive read access to the complete `$DOWNLOAD` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-download-recursive`",
+          "type": "string",
+          "const": "fs:allow-download-read-recursive",
+          "markdownDescription": "This allows full recursive read access to the complete `$DOWNLOAD` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-download-recursive`"
+        },
+        {
+          "description": "This allows non-recursive write access to the `$DOWNLOAD` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-download`",
+          "type": "string",
+          "const": "fs:allow-download-write",
+          "markdownDescription": "This allows non-recursive write access to the `$DOWNLOAD` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-download`"
+        },
+        {
+          "description": "This allows full recursive write access to the complete `$DOWNLOAD` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-download-recursive`",
+          "type": "string",
+          "const": "fs:allow-download-write-recursive",
+          "markdownDescription": "This allows full recursive write access to the complete `$DOWNLOAD` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-download-recursive`"
+        },
+        {
+          "description": "This allows non-recursive read access to metadata of the `$EXE` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-exe-index`",
+          "type": "string",
+          "const": "fs:allow-exe-meta",
+          "markdownDescription": "This allows non-recursive read access to metadata of the `$EXE` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-exe-index`"
+        },
+        {
+          "description": "This allows full recursive read access to metadata of the `$EXE` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-exe-recursive`",
+          "type": "string",
+          "const": "fs:allow-exe-meta-recursive",
+          "markdownDescription": "This allows full recursive read access to metadata of the `$EXE` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-exe-recursive`"
+        },
+        {
+          "description": "This allows non-recursive read access to the `$EXE` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-exe`",
+          "type": "string",
+          "const": "fs:allow-exe-read",
+          "markdownDescription": "This allows non-recursive read access to the `$EXE` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-exe`"
+        },
+        {
+          "description": "This allows full recursive read access to the complete `$EXE` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-exe-recursive`",
+          "type": "string",
+          "const": "fs:allow-exe-read-recursive",
+          "markdownDescription": "This allows full recursive read access to the complete `$EXE` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-exe-recursive`"
+        },
+        {
+          "description": "This allows non-recursive write access to the `$EXE` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-exe`",
+          "type": "string",
+          "const": "fs:allow-exe-write",
+          "markdownDescription": "This allows non-recursive write access to the `$EXE` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-exe`"
+        },
+        {
+          "description": "This allows full recursive write access to the complete `$EXE` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-exe-recursive`",
+          "type": "string",
+          "const": "fs:allow-exe-write-recursive",
+          "markdownDescription": "This allows full recursive write access to the complete `$EXE` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-exe-recursive`"
+        },
+        {
+          "description": "This allows non-recursive read access to metadata of the `$FONT` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-font-index`",
+          "type": "string",
+          "const": "fs:allow-font-meta",
+          "markdownDescription": "This allows non-recursive read access to metadata of the `$FONT` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-font-index`"
+        },
+        {
+          "description": "This allows full recursive read access to metadata of the `$FONT` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-font-recursive`",
+          "type": "string",
+          "const": "fs:allow-font-meta-recursive",
+          "markdownDescription": "This allows full recursive read access to metadata of the `$FONT` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-font-recursive`"
+        },
+        {
+          "description": "This allows non-recursive read access to the `$FONT` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-font`",
+          "type": "string",
+          "const": "fs:allow-font-read",
+          "markdownDescription": "This allows non-recursive read access to the `$FONT` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-font`"
+        },
+        {
+          "description": "This allows full recursive read access to the complete `$FONT` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-font-recursive`",
+          "type": "string",
+          "const": "fs:allow-font-read-recursive",
+          "markdownDescription": "This allows full recursive read access to the complete `$FONT` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-font-recursive`"
+        },
+        {
+          "description": "This allows non-recursive write access to the `$FONT` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-font`",
+          "type": "string",
+          "const": "fs:allow-font-write",
+          "markdownDescription": "This allows non-recursive write access to the `$FONT` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-font`"
+        },
+        {
+          "description": "This allows full recursive write access to the complete `$FONT` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-font-recursive`",
+          "type": "string",
+          "const": "fs:allow-font-write-recursive",
+          "markdownDescription": "This allows full recursive write access to the complete `$FONT` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-font-recursive`"
+        },
+        {
+          "description": "This allows non-recursive read access to metadata of the `$HOME` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-home-index`",
+          "type": "string",
+          "const": "fs:allow-home-meta",
+          "markdownDescription": "This allows non-recursive read access to metadata of the `$HOME` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-home-index`"
+        },
+        {
+          "description": "This allows full recursive read access to metadata of the `$HOME` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-home-recursive`",
+          "type": "string",
+          "const": "fs:allow-home-meta-recursive",
+          "markdownDescription": "This allows full recursive read access to metadata of the `$HOME` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-home-recursive`"
+        },
+        {
+          "description": "This allows non-recursive read access to the `$HOME` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-home`",
+          "type": "string",
+          "const": "fs:allow-home-read",
+          "markdownDescription": "This allows non-recursive read access to the `$HOME` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-home`"
+        },
+        {
+          "description": "This allows full recursive read access to the complete `$HOME` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-home-recursive`",
+          "type": "string",
+          "const": "fs:allow-home-read-recursive",
+          "markdownDescription": "This allows full recursive read access to the complete `$HOME` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-home-recursive`"
+        },
+        {
+          "description": "This allows non-recursive write access to the `$HOME` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-home`",
+          "type": "string",
+          "const": "fs:allow-home-write",
+          "markdownDescription": "This allows non-recursive write access to the `$HOME` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-home`"
+        },
+        {
+          "description": "This allows full recursive write access to the complete `$HOME` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-home-recursive`",
+          "type": "string",
+          "const": "fs:allow-home-write-recursive",
+          "markdownDescription": "This allows full recursive write access to the complete `$HOME` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-home-recursive`"
+        },
+        {
+          "description": "This allows non-recursive read access to metadata of the `$LOCALDATA` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-localdata-index`",
+          "type": "string",
+          "const": "fs:allow-localdata-meta",
+          "markdownDescription": "This allows non-recursive read access to metadata of the `$LOCALDATA` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-localdata-index`"
+        },
+        {
+          "description": "This allows full recursive read access to metadata of the `$LOCALDATA` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-localdata-recursive`",
+          "type": "string",
+          "const": "fs:allow-localdata-meta-recursive",
+          "markdownDescription": "This allows full recursive read access to metadata of the `$LOCALDATA` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-localdata-recursive`"
+        },
+        {
+          "description": "This allows non-recursive read access to the `$LOCALDATA` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-localdata`",
+          "type": "string",
+          "const": "fs:allow-localdata-read",
+          "markdownDescription": "This allows non-recursive read access to the `$LOCALDATA` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-localdata`"
+        },
+        {
+          "description": "This allows full recursive read access to the complete `$LOCALDATA` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-localdata-recursive`",
+          "type": "string",
+          "const": "fs:allow-localdata-read-recursive",
+          "markdownDescription": "This allows full recursive read access to the complete `$LOCALDATA` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-localdata-recursive`"
+        },
+        {
+          "description": "This allows non-recursive write access to the `$LOCALDATA` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-localdata`",
+          "type": "string",
+          "const": "fs:allow-localdata-write",
+          "markdownDescription": "This allows non-recursive write access to the `$LOCALDATA` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-localdata`"
+        },
+        {
+          "description": "This allows full recursive write access to the complete `$LOCALDATA` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-localdata-recursive`",
+          "type": "string",
+          "const": "fs:allow-localdata-write-recursive",
+          "markdownDescription": "This allows full recursive write access to the complete `$LOCALDATA` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-localdata-recursive`"
+        },
+        {
+          "description": "This allows non-recursive read access to metadata of the `$LOG` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-log-index`",
+          "type": "string",
+          "const": "fs:allow-log-meta",
+          "markdownDescription": "This allows non-recursive read access to metadata of the `$LOG` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-log-index`"
+        },
+        {
+          "description": "This allows full recursive read access to metadata of the `$LOG` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-log-recursive`",
+          "type": "string",
+          "const": "fs:allow-log-meta-recursive",
+          "markdownDescription": "This allows full recursive read access to metadata of the `$LOG` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-log-recursive`"
+        },
+        {
+          "description": "This allows non-recursive read access to the `$LOG` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-log`",
+          "type": "string",
+          "const": "fs:allow-log-read",
+          "markdownDescription": "This allows non-recursive read access to the `$LOG` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-log`"
+        },
+        {
+          "description": "This allows full recursive read access to the complete `$LOG` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-log-recursive`",
+          "type": "string",
+          "const": "fs:allow-log-read-recursive",
+          "markdownDescription": "This allows full recursive read access to the complete `$LOG` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-log-recursive`"
+        },
+        {
+          "description": "This allows non-recursive write access to the `$LOG` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-log`",
+          "type": "string",
+          "const": "fs:allow-log-write",
+          "markdownDescription": "This allows non-recursive write access to the `$LOG` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-log`"
+        },
+        {
+          "description": "This allows full recursive write access to the complete `$LOG` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-log-recursive`",
+          "type": "string",
+          "const": "fs:allow-log-write-recursive",
+          "markdownDescription": "This allows full recursive write access to the complete `$LOG` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-log-recursive`"
+        },
+        {
+          "description": "This allows non-recursive read access to metadata of the `$PICTURE` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-picture-index`",
+          "type": "string",
+          "const": "fs:allow-picture-meta",
+          "markdownDescription": "This allows non-recursive read access to metadata of the `$PICTURE` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-picture-index`"
+        },
+        {
+          "description": "This allows full recursive read access to metadata of the `$PICTURE` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-picture-recursive`",
+          "type": "string",
+          "const": "fs:allow-picture-meta-recursive",
+          "markdownDescription": "This allows full recursive read access to metadata of the `$PICTURE` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-picture-recursive`"
+        },
+        {
+          "description": "This allows non-recursive read access to the `$PICTURE` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-picture`",
+          "type": "string",
+          "const": "fs:allow-picture-read",
+          "markdownDescription": "This allows non-recursive read access to the `$PICTURE` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-picture`"
+        },
+        {
+          "description": "This allows full recursive read access to the complete `$PICTURE` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-picture-recursive`",
+          "type": "string",
+          "const": "fs:allow-picture-read-recursive",
+          "markdownDescription": "This allows full recursive read access to the complete `$PICTURE` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-picture-recursive`"
+        },
+        {
+          "description": "This allows non-recursive write access to the `$PICTURE` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-picture`",
+          "type": "string",
+          "const": "fs:allow-picture-write",
+          "markdownDescription": "This allows non-recursive write access to the `$PICTURE` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-picture`"
+        },
+        {
+          "description": "This allows full recursive write access to the complete `$PICTURE` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-picture-recursive`",
+          "type": "string",
+          "const": "fs:allow-picture-write-recursive",
+          "markdownDescription": "This allows full recursive write access to the complete `$PICTURE` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-picture-recursive`"
+        },
+        {
+          "description": "This allows non-recursive read access to metadata of the `$PUBLIC` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-public-index`",
+          "type": "string",
+          "const": "fs:allow-public-meta",
+          "markdownDescription": "This allows non-recursive read access to metadata of the `$PUBLIC` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-public-index`"
+        },
+        {
+          "description": "This allows full recursive read access to metadata of the `$PUBLIC` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-public-recursive`",
+          "type": "string",
+          "const": "fs:allow-public-meta-recursive",
+          "markdownDescription": "This allows full recursive read access to metadata of the `$PUBLIC` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-public-recursive`"
+        },
+        {
+          "description": "This allows non-recursive read access to the `$PUBLIC` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-public`",
+          "type": "string",
+          "const": "fs:allow-public-read",
+          "markdownDescription": "This allows non-recursive read access to the `$PUBLIC` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-public`"
+        },
+        {
+          "description": "This allows full recursive read access to the complete `$PUBLIC` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-public-recursive`",
+          "type": "string",
+          "const": "fs:allow-public-read-recursive",
+          "markdownDescription": "This allows full recursive read access to the complete `$PUBLIC` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-public-recursive`"
+        },
+        {
+          "description": "This allows non-recursive write access to the `$PUBLIC` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-public`",
+          "type": "string",
+          "const": "fs:allow-public-write",
+          "markdownDescription": "This allows non-recursive write access to the `$PUBLIC` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-public`"
+        },
+        {
+          "description": "This allows full recursive write access to the complete `$PUBLIC` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-public-recursive`",
+          "type": "string",
+          "const": "fs:allow-public-write-recursive",
+          "markdownDescription": "This allows full recursive write access to the complete `$PUBLIC` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-public-recursive`"
+        },
+        {
+          "description": "This allows non-recursive read access to metadata of the `$RESOURCE` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-resource-index`",
+          "type": "string",
+          "const": "fs:allow-resource-meta",
+          "markdownDescription": "This allows non-recursive read access to metadata of the `$RESOURCE` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-resource-index`"
+        },
+        {
+          "description": "This allows full recursive read access to metadata of the `$RESOURCE` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-resource-recursive`",
+          "type": "string",
+          "const": "fs:allow-resource-meta-recursive",
+          "markdownDescription": "This allows full recursive read access to metadata of the `$RESOURCE` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-resource-recursive`"
+        },
+        {
+          "description": "This allows non-recursive read access to the `$RESOURCE` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-resource`",
+          "type": "string",
+          "const": "fs:allow-resource-read",
+          "markdownDescription": "This allows non-recursive read access to the `$RESOURCE` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-resource`"
+        },
+        {
+          "description": "This allows full recursive read access to the complete `$RESOURCE` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-resource-recursive`",
+          "type": "string",
+          "const": "fs:allow-resource-read-recursive",
+          "markdownDescription": "This allows full recursive read access to the complete `$RESOURCE` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-resource-recursive`"
+        },
+        {
+          "description": "This allows non-recursive write access to the `$RESOURCE` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-resource`",
+          "type": "string",
+          "const": "fs:allow-resource-write",
+          "markdownDescription": "This allows non-recursive write access to the `$RESOURCE` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-resource`"
+        },
+        {
+          "description": "This allows full recursive write access to the complete `$RESOURCE` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-resource-recursive`",
+          "type": "string",
+          "const": "fs:allow-resource-write-recursive",
+          "markdownDescription": "This allows full recursive write access to the complete `$RESOURCE` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-resource-recursive`"
+        },
+        {
+          "description": "This allows non-recursive read access to metadata of the `$RUNTIME` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-runtime-index`",
+          "type": "string",
+          "const": "fs:allow-runtime-meta",
+          "markdownDescription": "This allows non-recursive read access to metadata of the `$RUNTIME` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-runtime-index`"
+        },
+        {
+          "description": "This allows full recursive read access to metadata of the `$RUNTIME` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-runtime-recursive`",
+          "type": "string",
+          "const": "fs:allow-runtime-meta-recursive",
+          "markdownDescription": "This allows full recursive read access to metadata of the `$RUNTIME` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-runtime-recursive`"
+        },
+        {
+          "description": "This allows non-recursive read access to the `$RUNTIME` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-runtime`",
+          "type": "string",
+          "const": "fs:allow-runtime-read",
+          "markdownDescription": "This allows non-recursive read access to the `$RUNTIME` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-runtime`"
+        },
+        {
+          "description": "This allows full recursive read access to the complete `$RUNTIME` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-runtime-recursive`",
+          "type": "string",
+          "const": "fs:allow-runtime-read-recursive",
+          "markdownDescription": "This allows full recursive read access to the complete `$RUNTIME` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-runtime-recursive`"
+        },
+        {
+          "description": "This allows non-recursive write access to the `$RUNTIME` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-runtime`",
+          "type": "string",
+          "const": "fs:allow-runtime-write",
+          "markdownDescription": "This allows non-recursive write access to the `$RUNTIME` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-runtime`"
+        },
+        {
+          "description": "This allows full recursive write access to the complete `$RUNTIME` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-runtime-recursive`",
+          "type": "string",
+          "const": "fs:allow-runtime-write-recursive",
+          "markdownDescription": "This allows full recursive write access to the complete `$RUNTIME` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-runtime-recursive`"
+        },
+        {
+          "description": "This allows non-recursive read access to metadata of the `$TEMP` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-temp-index`",
+          "type": "string",
+          "const": "fs:allow-temp-meta",
+          "markdownDescription": "This allows non-recursive read access to metadata of the `$TEMP` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-temp-index`"
+        },
+        {
+          "description": "This allows full recursive read access to metadata of the `$TEMP` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-temp-recursive`",
+          "type": "string",
+          "const": "fs:allow-temp-meta-recursive",
+          "markdownDescription": "This allows full recursive read access to metadata of the `$TEMP` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-temp-recursive`"
+        },
+        {
+          "description": "This allows non-recursive read access to the `$TEMP` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-temp`",
+          "type": "string",
+          "const": "fs:allow-temp-read",
+          "markdownDescription": "This allows non-recursive read access to the `$TEMP` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-temp`"
+        },
+        {
+          "description": "This allows full recursive read access to the complete `$TEMP` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-temp-recursive`",
+          "type": "string",
+          "const": "fs:allow-temp-read-recursive",
+          "markdownDescription": "This allows full recursive read access to the complete `$TEMP` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-temp-recursive`"
+        },
+        {
+          "description": "This allows non-recursive write access to the `$TEMP` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-temp`",
+          "type": "string",
+          "const": "fs:allow-temp-write",
+          "markdownDescription": "This allows non-recursive write access to the `$TEMP` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-temp`"
+        },
+        {
+          "description": "This allows full recursive write access to the complete `$TEMP` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-temp-recursive`",
+          "type": "string",
+          "const": "fs:allow-temp-write-recursive",
+          "markdownDescription": "This allows full recursive write access to the complete `$TEMP` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-temp-recursive`"
+        },
+        {
+          "description": "This allows non-recursive read access to metadata of the `$TEMPLATE` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-template-index`",
+          "type": "string",
+          "const": "fs:allow-template-meta",
+          "markdownDescription": "This allows non-recursive read access to metadata of the `$TEMPLATE` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-template-index`"
+        },
+        {
+          "description": "This allows full recursive read access to metadata of the `$TEMPLATE` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-template-recursive`",
+          "type": "string",
+          "const": "fs:allow-template-meta-recursive",
+          "markdownDescription": "This allows full recursive read access to metadata of the `$TEMPLATE` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-template-recursive`"
+        },
+        {
+          "description": "This allows non-recursive read access to the `$TEMPLATE` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-template`",
+          "type": "string",
+          "const": "fs:allow-template-read",
+          "markdownDescription": "This allows non-recursive read access to the `$TEMPLATE` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-template`"
+        },
+        {
+          "description": "This allows full recursive read access to the complete `$TEMPLATE` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-template-recursive`",
+          "type": "string",
+          "const": "fs:allow-template-read-recursive",
+          "markdownDescription": "This allows full recursive read access to the complete `$TEMPLATE` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-template-recursive`"
+        },
+        {
+          "description": "This allows non-recursive write access to the `$TEMPLATE` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-template`",
+          "type": "string",
+          "const": "fs:allow-template-write",
+          "markdownDescription": "This allows non-recursive write access to the `$TEMPLATE` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-template`"
+        },
+        {
+          "description": "This allows full recursive write access to the complete `$TEMPLATE` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-template-recursive`",
+          "type": "string",
+          "const": "fs:allow-template-write-recursive",
+          "markdownDescription": "This allows full recursive write access to the complete `$TEMPLATE` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-template-recursive`"
+        },
+        {
+          "description": "This allows non-recursive read access to metadata of the `$VIDEO` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-video-index`",
+          "type": "string",
+          "const": "fs:allow-video-meta",
+          "markdownDescription": "This allows non-recursive read access to metadata of the `$VIDEO` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-video-index`"
+        },
+        {
+          "description": "This allows full recursive read access to metadata of the `$VIDEO` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-video-recursive`",
+          "type": "string",
+          "const": "fs:allow-video-meta-recursive",
+          "markdownDescription": "This allows full recursive read access to metadata of the `$VIDEO` folder, including file listing and statistics.\n#### This permission set includes:\n\n- `read-meta`\n- `scope-video-recursive`"
+        },
+        {
+          "description": "This allows non-recursive read access to the `$VIDEO` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-video`",
+          "type": "string",
+          "const": "fs:allow-video-read",
+          "markdownDescription": "This allows non-recursive read access to the `$VIDEO` folder.\n#### This permission set includes:\n\n- `read-all`\n- `scope-video`"
+        },
+        {
+          "description": "This allows full recursive read access to the complete `$VIDEO` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-video-recursive`",
+          "type": "string",
+          "const": "fs:allow-video-read-recursive",
+          "markdownDescription": "This allows full recursive read access to the complete `$VIDEO` folder, files and subdirectories.\n#### This permission set includes:\n\n- `read-all`\n- `scope-video-recursive`"
+        },
+        {
+          "description": "This allows non-recursive write access to the `$VIDEO` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-video`",
+          "type": "string",
+          "const": "fs:allow-video-write",
+          "markdownDescription": "This allows non-recursive write access to the `$VIDEO` folder.\n#### This permission set includes:\n\n- `write-all`\n- `scope-video`"
+        },
+        {
+          "description": "This allows full recursive write access to the complete `$VIDEO` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-video-recursive`",
+          "type": "string",
+          "const": "fs:allow-video-write-recursive",
+          "markdownDescription": "This allows full recursive write access to the complete `$VIDEO` folder, files and subdirectories.\n#### This permission set includes:\n\n- `write-all`\n- `scope-video-recursive`"
+        },
+        {
+          "description": "This denies access to dangerous Tauri relevant files and folders by default.\n#### This permission set includes:\n\n- `deny-webview-data-linux`\n- `deny-webview-data-windows`",
+          "type": "string",
+          "const": "fs:deny-default",
+          "markdownDescription": "This denies access to dangerous Tauri relevant files and folders by default.\n#### This permission set includes:\n\n- `deny-webview-data-linux`\n- `deny-webview-data-windows`"
+        },
+        {
+          "description": "Enables the copy_file command without any pre-configured scope.",
+          "type": "string",
+          "const": "fs:allow-copy-file",
+          "markdownDescription": "Enables the copy_file command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the create command without any pre-configured scope.",
+          "type": "string",
+          "const": "fs:allow-create",
+          "markdownDescription": "Enables the create command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the exists command without any pre-configured scope.",
+          "type": "string",
+          "const": "fs:allow-exists",
+          "markdownDescription": "Enables the exists command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the fstat command without any pre-configured scope.",
+          "type": "string",
+          "const": "fs:allow-fstat",
+          "markdownDescription": "Enables the fstat command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the ftruncate command without any pre-configured scope.",
+          "type": "string",
+          "const": "fs:allow-ftruncate",
+          "markdownDescription": "Enables the ftruncate command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the lstat command without any pre-configured scope.",
+          "type": "string",
+          "const": "fs:allow-lstat",
+          "markdownDescription": "Enables the lstat command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the mkdir command without any pre-configured scope.",
+          "type": "string",
+          "const": "fs:allow-mkdir",
+          "markdownDescription": "Enables the mkdir command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the open command without any pre-configured scope.",
+          "type": "string",
+          "const": "fs:allow-open",
+          "markdownDescription": "Enables the open command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the read command without any pre-configured scope.",
+          "type": "string",
+          "const": "fs:allow-read",
+          "markdownDescription": "Enables the read command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the read_dir command without any pre-configured scope.",
+          "type": "string",
+          "const": "fs:allow-read-dir",
+          "markdownDescription": "Enables the read_dir command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the read_file command without any pre-configured scope.",
+          "type": "string",
+          "const": "fs:allow-read-file",
+          "markdownDescription": "Enables the read_file command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the read_text_file command without any pre-configured scope.",
+          "type": "string",
+          "const": "fs:allow-read-text-file",
+          "markdownDescription": "Enables the read_text_file command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the read_text_file_lines command without any pre-configured scope.",
+          "type": "string",
+          "const": "fs:allow-read-text-file-lines",
+          "markdownDescription": "Enables the read_text_file_lines command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the read_text_file_lines_next command without any pre-configured scope.",
+          "type": "string",
+          "const": "fs:allow-read-text-file-lines-next",
+          "markdownDescription": "Enables the read_text_file_lines_next command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the remove command without any pre-configured scope.",
+          "type": "string",
+          "const": "fs:allow-remove",
+          "markdownDescription": "Enables the remove command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the rename command without any pre-configured scope.",
+          "type": "string",
+          "const": "fs:allow-rename",
+          "markdownDescription": "Enables the rename command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the seek command without any pre-configured scope.",
+          "type": "string",
+          "const": "fs:allow-seek",
+          "markdownDescription": "Enables the seek command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the size command without any pre-configured scope.",
+          "type": "string",
+          "const": "fs:allow-size",
+          "markdownDescription": "Enables the size command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the start_accessing_security_scoped_resource command without any pre-configured scope.",
+          "type": "string",
+          "const": "fs:allow-start-accessing-security-scoped-resource",
+          "markdownDescription": "Enables the start_accessing_security_scoped_resource command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the stat command without any pre-configured scope.",
+          "type": "string",
+          "const": "fs:allow-stat",
+          "markdownDescription": "Enables the stat command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the stop_accessing_security_scoped_resource command without any pre-configured scope.",
+          "type": "string",
+          "const": "fs:allow-stop-accessing-security-scoped-resource",
+          "markdownDescription": "Enables the stop_accessing_security_scoped_resource command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the truncate command without any pre-configured scope.",
+          "type": "string",
+          "const": "fs:allow-truncate",
+          "markdownDescription": "Enables the truncate command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the unwatch command without any pre-configured scope.",
+          "type": "string",
+          "const": "fs:allow-unwatch",
+          "markdownDescription": "Enables the unwatch command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the watch command without any pre-configured scope.",
+          "type": "string",
+          "const": "fs:allow-watch",
+          "markdownDescription": "Enables the watch command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the write command without any pre-configured scope.",
+          "type": "string",
+          "const": "fs:allow-write",
+          "markdownDescription": "Enables the write command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the write_file command without any pre-configured scope.",
+          "type": "string",
+          "const": "fs:allow-write-file",
+          "markdownDescription": "Enables the write_file command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the write_text_file command without any pre-configured scope.",
+          "type": "string",
+          "const": "fs:allow-write-text-file",
+          "markdownDescription": "Enables the write_text_file command without any pre-configured scope."
+        },
+        {
+          "description": "This permissions allows to create the application specific directories.\n",
+          "type": "string",
+          "const": "fs:create-app-specific-dirs",
+          "markdownDescription": "This permissions allows to create the application specific directories.\n"
+        },
+        {
+          "description": "Denies the copy_file command without any pre-configured scope.",
+          "type": "string",
+          "const": "fs:deny-copy-file",
+          "markdownDescription": "Denies the copy_file command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the create command without any pre-configured scope.",
+          "type": "string",
+          "const": "fs:deny-create",
+          "markdownDescription": "Denies the create command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the exists command without any pre-configured scope.",
+          "type": "string",
+          "const": "fs:deny-exists",
+          "markdownDescription": "Denies the exists command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the fstat command without any pre-configured scope.",
+          "type": "string",
+          "const": "fs:deny-fstat",
+          "markdownDescription": "Denies the fstat command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the ftruncate command without any pre-configured scope.",
+          "type": "string",
+          "const": "fs:deny-ftruncate",
+          "markdownDescription": "Denies the ftruncate command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the lstat command without any pre-configured scope.",
+          "type": "string",
+          "const": "fs:deny-lstat",
+          "markdownDescription": "Denies the lstat command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the mkdir command without any pre-configured scope.",
+          "type": "string",
+          "const": "fs:deny-mkdir",
+          "markdownDescription": "Denies the mkdir command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the open command without any pre-configured scope.",
+          "type": "string",
+          "const": "fs:deny-open",
+          "markdownDescription": "Denies the open command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the read command without any pre-configured scope.",
+          "type": "string",
+          "const": "fs:deny-read",
+          "markdownDescription": "Denies the read command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the read_dir command without any pre-configured scope.",
+          "type": "string",
+          "const": "fs:deny-read-dir",
+          "markdownDescription": "Denies the read_dir command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the read_file command without any pre-configured scope.",
+          "type": "string",
+          "const": "fs:deny-read-file",
+          "markdownDescription": "Denies the read_file command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the read_text_file command without any pre-configured scope.",
+          "type": "string",
+          "const": "fs:deny-read-text-file",
+          "markdownDescription": "Denies the read_text_file command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the read_text_file_lines command without any pre-configured scope.",
+          "type": "string",
+          "const": "fs:deny-read-text-file-lines",
+          "markdownDescription": "Denies the read_text_file_lines command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the read_text_file_lines_next command without any pre-configured scope.",
+          "type": "string",
+          "const": "fs:deny-read-text-file-lines-next",
+          "markdownDescription": "Denies the read_text_file_lines_next command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the remove command without any pre-configured scope.",
+          "type": "string",
+          "const": "fs:deny-remove",
+          "markdownDescription": "Denies the remove command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the rename command without any pre-configured scope.",
+          "type": "string",
+          "const": "fs:deny-rename",
+          "markdownDescription": "Denies the rename command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the seek command without any pre-configured scope.",
+          "type": "string",
+          "const": "fs:deny-seek",
+          "markdownDescription": "Denies the seek command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the size command without any pre-configured scope.",
+          "type": "string",
+          "const": "fs:deny-size",
+          "markdownDescription": "Denies the size command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the start_accessing_security_scoped_resource command without any pre-configured scope.",
+          "type": "string",
+          "const": "fs:deny-start-accessing-security-scoped-resource",
+          "markdownDescription": "Denies the start_accessing_security_scoped_resource command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the stat command without any pre-configured scope.",
+          "type": "string",
+          "const": "fs:deny-stat",
+          "markdownDescription": "Denies the stat command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the stop_accessing_security_scoped_resource command without any pre-configured scope.",
+          "type": "string",
+          "const": "fs:deny-stop-accessing-security-scoped-resource",
+          "markdownDescription": "Denies the stop_accessing_security_scoped_resource command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the truncate command without any pre-configured scope.",
+          "type": "string",
+          "const": "fs:deny-truncate",
+          "markdownDescription": "Denies the truncate command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the unwatch command without any pre-configured scope.",
+          "type": "string",
+          "const": "fs:deny-unwatch",
+          "markdownDescription": "Denies the unwatch command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the watch command without any pre-configured scope.",
+          "type": "string",
+          "const": "fs:deny-watch",
+          "markdownDescription": "Denies the watch command without any pre-configured scope."
+        },
+        {
+          "description": "This denies read access to the\n`$APPLOCALDATA` folder on linux as the webview data and configuration values are stored here.\nAllowing access can lead to sensitive information disclosure and should be well considered.",
+          "type": "string",
+          "const": "fs:deny-webview-data-linux",
+          "markdownDescription": "This denies read access to the\n`$APPLOCALDATA` folder on linux as the webview data and configuration values are stored here.\nAllowing access can lead to sensitive information disclosure and should be well considered."
+        },
+        {
+          "description": "This denies read access to the\n`$APPLOCALDATA/EBWebView` folder on windows as the webview data and configuration values are stored here.\nAllowing access can lead to sensitive information disclosure and should be well considered.",
+          "type": "string",
+          "const": "fs:deny-webview-data-windows",
+          "markdownDescription": "This denies read access to the\n`$APPLOCALDATA/EBWebView` folder on windows as the webview data and configuration values are stored here.\nAllowing access can lead to sensitive information disclosure and should be well considered."
+        },
+        {
+          "description": "Denies the write command without any pre-configured scope.",
+          "type": "string",
+          "const": "fs:deny-write",
+          "markdownDescription": "Denies the write command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the write_file command without any pre-configured scope.",
+          "type": "string",
+          "const": "fs:deny-write-file",
+          "markdownDescription": "Denies the write_file command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the write_text_file command without any pre-configured scope.",
+          "type": "string",
+          "const": "fs:deny-write-text-file",
+          "markdownDescription": "Denies the write_text_file command without any pre-configured scope."
+        },
+        {
+          "description": "This enables all read related commands without any pre-configured accessible paths.",
+          "type": "string",
+          "const": "fs:read-all",
+          "markdownDescription": "This enables all read related commands without any pre-configured accessible paths."
+        },
+        {
+          "description": "This permission allows recursive read functionality on the application\nspecific base directories. \n",
+          "type": "string",
+          "const": "fs:read-app-specific-dirs-recursive",
+          "markdownDescription": "This permission allows recursive read functionality on the application\nspecific base directories. \n"
+        },
+        {
+          "description": "This enables directory read and file metadata related commands without any pre-configured accessible paths.",
+          "type": "string",
+          "const": "fs:read-dirs",
+          "markdownDescription": "This enables directory read and file metadata related commands without any pre-configured accessible paths."
+        },
+        {
+          "description": "This enables file read related commands without any pre-configured accessible paths.",
+          "type": "string",
+          "const": "fs:read-files",
+          "markdownDescription": "This enables file read related commands without any pre-configured accessible paths."
+        },
+        {
+          "description": "This enables all index or metadata related commands without any pre-configured accessible paths.",
+          "type": "string",
+          "const": "fs:read-meta",
+          "markdownDescription": "This enables all index or metadata related commands without any pre-configured accessible paths."
+        },
+        {
+          "description": "An empty permission you can use to modify the global scope.\n\n## Example\n\n```json\n{\n  \"identifier\": \"read-documents\",\n  \"windows\": [\"main\"],\n  \"permissions\": [\n    \"fs:allow-read\",\n    {\n      \"identifier\": \"fs:scope\",\n      \"allow\": [\n        \"$APPDATA/documents/**/*\"\n      ],\n      \"deny\": [\n        \"$APPDATA/documents/secret.txt\"\n      ]\n    }\n  ]\n}\n```\n",
+          "type": "string",
+          "const": "fs:scope",
+          "markdownDescription": "An empty permission you can use to modify the global scope.\n\n## Example\n\n```json\n{\n  \"identifier\": \"read-documents\",\n  \"windows\": [\"main\"],\n  \"permissions\": [\n    \"fs:allow-read\",\n    {\n      \"identifier\": \"fs:scope\",\n      \"allow\": [\n        \"$APPDATA/documents/**/*\"\n      ],\n      \"deny\": [\n        \"$APPDATA/documents/secret.txt\"\n      ]\n    }\n  ]\n}\n```\n"
+        },
+        {
+          "description": "This scope permits access to all files and list content of top level directories in the application folders.",
+          "type": "string",
+          "const": "fs:scope-app",
+          "markdownDescription": "This scope permits access to all files and list content of top level directories in the application folders."
+        },
+        {
+          "description": "This scope permits to list all files and folders in the application directories.",
+          "type": "string",
+          "const": "fs:scope-app-index",
+          "markdownDescription": "This scope permits to list all files and folders in the application directories."
+        },
+        {
+          "description": "This scope permits recursive access to the complete application folders, including sub directories and files.",
+          "type": "string",
+          "const": "fs:scope-app-recursive",
+          "markdownDescription": "This scope permits recursive access to the complete application folders, including sub directories and files."
+        },
+        {
+          "description": "This scope permits access to all files and list content of top level directories in the `$APPCACHE` folder.",
+          "type": "string",
+          "const": "fs:scope-appcache",
+          "markdownDescription": "This scope permits access to all files and list content of top level directories in the `$APPCACHE` folder."
+        },
+        {
+          "description": "This scope permits to list all files and folders in the `$APPCACHE`folder.",
+          "type": "string",
+          "const": "fs:scope-appcache-index",
+          "markdownDescription": "This scope permits to list all files and folders in the `$APPCACHE`folder."
+        },
+        {
+          "description": "This scope permits recursive access to the complete `$APPCACHE` folder, including sub directories and files.",
+          "type": "string",
+          "const": "fs:scope-appcache-recursive",
+          "markdownDescription": "This scope permits recursive access to the complete `$APPCACHE` folder, including sub directories and files."
+        },
+        {
+          "description": "This scope permits access to all files and list content of top level directories in the `$APPCONFIG` folder.",
+          "type": "string",
+          "const": "fs:scope-appconfig",
+          "markdownDescription": "This scope permits access to all files and list content of top level directories in the `$APPCONFIG` folder."
+        },
+        {
+          "description": "This scope permits to list all files and folders in the `$APPCONFIG`folder.",
+          "type": "string",
+          "const": "fs:scope-appconfig-index",
+          "markdownDescription": "This scope permits to list all files and folders in the `$APPCONFIG`folder."
+        },
+        {
+          "description": "This scope permits recursive access to the complete `$APPCONFIG` folder, including sub directories and files.",
+          "type": "string",
+          "const": "fs:scope-appconfig-recursive",
+          "markdownDescription": "This scope permits recursive access to the complete `$APPCONFIG` folder, including sub directories and files."
+        },
+        {
+          "description": "This scope permits access to all files and list content of top level directories in the `$APPDATA` folder.",
+          "type": "string",
+          "const": "fs:scope-appdata",
+          "markdownDescription": "This scope permits access to all files and list content of top level directories in the `$APPDATA` folder."
+        },
+        {
+          "description": "This scope permits to list all files and folders in the `$APPDATA`folder.",
+          "type": "string",
+          "const": "fs:scope-appdata-index",
+          "markdownDescription": "This scope permits to list all files and folders in the `$APPDATA`folder."
+        },
+        {
+          "description": "This scope permits recursive access to the complete `$APPDATA` folder, including sub directories and files.",
+          "type": "string",
+          "const": "fs:scope-appdata-recursive",
+          "markdownDescription": "This scope permits recursive access to the complete `$APPDATA` folder, including sub directories and files."
+        },
+        {
+          "description": "This scope permits access to all files and list content of top level directories in the `$APPLOCALDATA` folder.",
+          "type": "string",
+          "const": "fs:scope-applocaldata",
+          "markdownDescription": "This scope permits access to all files and list content of top level directories in the `$APPLOCALDATA` folder."
+        },
+        {
+          "description": "This scope permits to list all files and folders in the `$APPLOCALDATA`folder.",
+          "type": "string",
+          "const": "fs:scope-applocaldata-index",
+          "markdownDescription": "This scope permits to list all files and folders in the `$APPLOCALDATA`folder."
+        },
+        {
+          "description": "This scope permits recursive access to the complete `$APPLOCALDATA` folder, including sub directories and files.",
+          "type": "string",
+          "const": "fs:scope-applocaldata-recursive",
+          "markdownDescription": "This scope permits recursive access to the complete `$APPLOCALDATA` folder, including sub directories and files."
+        },
+        {
+          "description": "This scope permits access to all files and list content of top level directories in the `$APPLOG` folder.",
+          "type": "string",
+          "const": "fs:scope-applog",
+          "markdownDescription": "This scope permits access to all files and list content of top level directories in the `$APPLOG` folder."
+        },
+        {
+          "description": "This scope permits to list all files and folders in the `$APPLOG`folder.",
+          "type": "string",
+          "const": "fs:scope-applog-index",
+          "markdownDescription": "This scope permits to list all files and folders in the `$APPLOG`folder."
+        },
+        {
+          "description": "This scope permits recursive access to the complete `$APPLOG` folder, including sub directories and files.",
+          "type": "string",
+          "const": "fs:scope-applog-recursive",
+          "markdownDescription": "This scope permits recursive access to the complete `$APPLOG` folder, including sub directories and files."
+        },
+        {
+          "description": "This scope permits access to all files and list content of top level directories in the `$AUDIO` folder.",
+          "type": "string",
+          "const": "fs:scope-audio",
+          "markdownDescription": "This scope permits access to all files and list content of top level directories in the `$AUDIO` folder."
+        },
+        {
+          "description": "This scope permits to list all files and folders in the `$AUDIO`folder.",
+          "type": "string",
+          "const": "fs:scope-audio-index",
+          "markdownDescription": "This scope permits to list all files and folders in the `$AUDIO`folder."
+        },
+        {
+          "description": "This scope permits recursive access to the complete `$AUDIO` folder, including sub directories and files.",
+          "type": "string",
+          "const": "fs:scope-audio-recursive",
+          "markdownDescription": "This scope permits recursive access to the complete `$AUDIO` folder, including sub directories and files."
+        },
+        {
+          "description": "This scope permits access to all files and list content of top level directories in the `$CACHE` folder.",
+          "type": "string",
+          "const": "fs:scope-cache",
+          "markdownDescription": "This scope permits access to all files and list content of top level directories in the `$CACHE` folder."
+        },
+        {
+          "description": "This scope permits to list all files and folders in the `$CACHE`folder.",
+          "type": "string",
+          "const": "fs:scope-cache-index",
+          "markdownDescription": "This scope permits to list all files and folders in the `$CACHE`folder."
+        },
+        {
+          "description": "This scope permits recursive access to the complete `$CACHE` folder, including sub directories and files.",
+          "type": "string",
+          "const": "fs:scope-cache-recursive",
+          "markdownDescription": "This scope permits recursive access to the complete `$CACHE` folder, including sub directories and files."
+        },
+        {
+          "description": "This scope permits access to all files and list content of top level directories in the `$CONFIG` folder.",
+          "type": "string",
+          "const": "fs:scope-config",
+          "markdownDescription": "This scope permits access to all files and list content of top level directories in the `$CONFIG` folder."
+        },
+        {
+          "description": "This scope permits to list all files and folders in the `$CONFIG`folder.",
+          "type": "string",
+          "const": "fs:scope-config-index",
+          "markdownDescription": "This scope permits to list all files and folders in the `$CONFIG`folder."
+        },
+        {
+          "description": "This scope permits recursive access to the complete `$CONFIG` folder, including sub directories and files.",
+          "type": "string",
+          "const": "fs:scope-config-recursive",
+          "markdownDescription": "This scope permits recursive access to the complete `$CONFIG` folder, including sub directories and files."
+        },
+        {
+          "description": "This scope permits access to all files and list content of top level directories in the `$DATA` folder.",
+          "type": "string",
+          "const": "fs:scope-data",
+          "markdownDescription": "This scope permits access to all files and list content of top level directories in the `$DATA` folder."
+        },
+        {
+          "description": "This scope permits to list all files and folders in the `$DATA`folder.",
+          "type": "string",
+          "const": "fs:scope-data-index",
+          "markdownDescription": "This scope permits to list all files and folders in the `$DATA`folder."
+        },
+        {
+          "description": "This scope permits recursive access to the complete `$DATA` folder, including sub directories and files.",
+          "type": "string",
+          "const": "fs:scope-data-recursive",
+          "markdownDescription": "This scope permits recursive access to the complete `$DATA` folder, including sub directories and files."
+        },
+        {
+          "description": "This scope permits access to all files and list content of top level directories in the `$DESKTOP` folder.",
+          "type": "string",
+          "const": "fs:scope-desktop",
+          "markdownDescription": "This scope permits access to all files and list content of top level directories in the `$DESKTOP` folder."
+        },
+        {
+          "description": "This scope permits to list all files and folders in the `$DESKTOP`folder.",
+          "type": "string",
+          "const": "fs:scope-desktop-index",
+          "markdownDescription": "This scope permits to list all files and folders in the `$DESKTOP`folder."
+        },
+        {
+          "description": "This scope permits recursive access to the complete `$DESKTOP` folder, including sub directories and files.",
+          "type": "string",
+          "const": "fs:scope-desktop-recursive",
+          "markdownDescription": "This scope permits recursive access to the complete `$DESKTOP` folder, including sub directories and files."
+        },
+        {
+          "description": "This scope permits access to all files and list content of top level directories in the `$DOCUMENT` folder.",
+          "type": "string",
+          "const": "fs:scope-document",
+          "markdownDescription": "This scope permits access to all files and list content of top level directories in the `$DOCUMENT` folder."
+        },
+        {
+          "description": "This scope permits to list all files and folders in the `$DOCUMENT`folder.",
+          "type": "string",
+          "const": "fs:scope-document-index",
+          "markdownDescription": "This scope permits to list all files and folders in the `$DOCUMENT`folder."
+        },
+        {
+          "description": "This scope permits recursive access to the complete `$DOCUMENT` folder, including sub directories and files.",
+          "type": "string",
+          "const": "fs:scope-document-recursive",
+          "markdownDescription": "This scope permits recursive access to the complete `$DOCUMENT` folder, including sub directories and files."
+        },
+        {
+          "description": "This scope permits access to all files and list content of top level directories in the `$DOWNLOAD` folder.",
+          "type": "string",
+          "const": "fs:scope-download",
+          "markdownDescription": "This scope permits access to all files and list content of top level directories in the `$DOWNLOAD` folder."
+        },
+        {
+          "description": "This scope permits to list all files and folders in the `$DOWNLOAD`folder.",
+          "type": "string",
+          "const": "fs:scope-download-index",
+          "markdownDescription": "This scope permits to list all files and folders in the `$DOWNLOAD`folder."
+        },
+        {
+          "description": "This scope permits recursive access to the complete `$DOWNLOAD` folder, including sub directories and files.",
+          "type": "string",
+          "const": "fs:scope-download-recursive",
+          "markdownDescription": "This scope permits recursive access to the complete `$DOWNLOAD` folder, including sub directories and files."
+        },
+        {
+          "description": "This scope permits access to all files and list content of top level directories in the `$EXE` folder.",
+          "type": "string",
+          "const": "fs:scope-exe",
+          "markdownDescription": "This scope permits access to all files and list content of top level directories in the `$EXE` folder."
+        },
+        {
+          "description": "This scope permits to list all files and folders in the `$EXE`folder.",
+          "type": "string",
+          "const": "fs:scope-exe-index",
+          "markdownDescription": "This scope permits to list all files and folders in the `$EXE`folder."
+        },
+        {
+          "description": "This scope permits recursive access to the complete `$EXE` folder, including sub directories and files.",
+          "type": "string",
+          "const": "fs:scope-exe-recursive",
+          "markdownDescription": "This scope permits recursive access to the complete `$EXE` folder, including sub directories and files."
+        },
+        {
+          "description": "This scope permits access to all files and list content of top level directories in the `$FONT` folder.",
+          "type": "string",
+          "const": "fs:scope-font",
+          "markdownDescription": "This scope permits access to all files and list content of top level directories in the `$FONT` folder."
+        },
+        {
+          "description": "This scope permits to list all files and folders in the `$FONT`folder.",
+          "type": "string",
+          "const": "fs:scope-font-index",
+          "markdownDescription": "This scope permits to list all files and folders in the `$FONT`folder."
+        },
+        {
+          "description": "This scope permits recursive access to the complete `$FONT` folder, including sub directories and files.",
+          "type": "string",
+          "const": "fs:scope-font-recursive",
+          "markdownDescription": "This scope permits recursive access to the complete `$FONT` folder, including sub directories and files."
+        },
+        {
+          "description": "This scope permits access to all files and list content of top level directories in the `$HOME` folder.",
+          "type": "string",
+          "const": "fs:scope-home",
+          "markdownDescription": "This scope permits access to all files and list content of top level directories in the `$HOME` folder."
+        },
+        {
+          "description": "This scope permits to list all files and folders in the `$HOME`folder.",
+          "type": "string",
+          "const": "fs:scope-home-index",
+          "markdownDescription": "This scope permits to list all files and folders in the `$HOME`folder."
+        },
+        {
+          "description": "This scope permits recursive access to the complete `$HOME` folder, including sub directories and files.",
+          "type": "string",
+          "const": "fs:scope-home-recursive",
+          "markdownDescription": "This scope permits recursive access to the complete `$HOME` folder, including sub directories and files."
+        },
+        {
+          "description": "This scope permits access to all files and list content of top level directories in the `$LOCALDATA` folder.",
+          "type": "string",
+          "const": "fs:scope-localdata",
+          "markdownDescription": "This scope permits access to all files and list content of top level directories in the `$LOCALDATA` folder."
+        },
+        {
+          "description": "This scope permits to list all files and folders in the `$LOCALDATA`folder.",
+          "type": "string",
+          "const": "fs:scope-localdata-index",
+          "markdownDescription": "This scope permits to list all files and folders in the `$LOCALDATA`folder."
+        },
+        {
+          "description": "This scope permits recursive access to the complete `$LOCALDATA` folder, including sub directories and files.",
+          "type": "string",
+          "const": "fs:scope-localdata-recursive",
+          "markdownDescription": "This scope permits recursive access to the complete `$LOCALDATA` folder, including sub directories and files."
+        },
+        {
+          "description": "This scope permits access to all files and list content of top level directories in the `$LOG` folder.",
+          "type": "string",
+          "const": "fs:scope-log",
+          "markdownDescription": "This scope permits access to all files and list content of top level directories in the `$LOG` folder."
+        },
+        {
+          "description": "This scope permits to list all files and folders in the `$LOG`folder.",
+          "type": "string",
+          "const": "fs:scope-log-index",
+          "markdownDescription": "This scope permits to list all files and folders in the `$LOG`folder."
+        },
+        {
+          "description": "This scope permits recursive access to the complete `$LOG` folder, including sub directories and files.",
+          "type": "string",
+          "const": "fs:scope-log-recursive",
+          "markdownDescription": "This scope permits recursive access to the complete `$LOG` folder, including sub directories and files."
+        },
+        {
+          "description": "This scope permits access to all files and list content of top level directories in the `$PICTURE` folder.",
+          "type": "string",
+          "const": "fs:scope-picture",
+          "markdownDescription": "This scope permits access to all files and list content of top level directories in the `$PICTURE` folder."
+        },
+        {
+          "description": "This scope permits to list all files and folders in the `$PICTURE`folder.",
+          "type": "string",
+          "const": "fs:scope-picture-index",
+          "markdownDescription": "This scope permits to list all files and folders in the `$PICTURE`folder."
+        },
+        {
+          "description": "This scope permits recursive access to the complete `$PICTURE` folder, including sub directories and files.",
+          "type": "string",
+          "const": "fs:scope-picture-recursive",
+          "markdownDescription": "This scope permits recursive access to the complete `$PICTURE` folder, including sub directories and files."
+        },
+        {
+          "description": "This scope permits access to all files and list content of top level directories in the `$PUBLIC` folder.",
+          "type": "string",
+          "const": "fs:scope-public",
+          "markdownDescription": "This scope permits access to all files and list content of top level directories in the `$PUBLIC` folder."
+        },
+        {
+          "description": "This scope permits to list all files and folders in the `$PUBLIC`folder.",
+          "type": "string",
+          "const": "fs:scope-public-index",
+          "markdownDescription": "This scope permits to list all files and folders in the `$PUBLIC`folder."
+        },
+        {
+          "description": "This scope permits recursive access to the complete `$PUBLIC` folder, including sub directories and files.",
+          "type": "string",
+          "const": "fs:scope-public-recursive",
+          "markdownDescription": "This scope permits recursive access to the complete `$PUBLIC` folder, including sub directories and files."
+        },
+        {
+          "description": "This scope permits access to all files and list content of top level directories in the `$RESOURCE` folder.",
+          "type": "string",
+          "const": "fs:scope-resource",
+          "markdownDescription": "This scope permits access to all files and list content of top level directories in the `$RESOURCE` folder."
+        },
+        {
+          "description": "This scope permits to list all files and folders in the `$RESOURCE`folder.",
+          "type": "string",
+          "const": "fs:scope-resource-index",
+          "markdownDescription": "This scope permits to list all files and folders in the `$RESOURCE`folder."
+        },
+        {
+          "description": "This scope permits recursive access to the complete `$RESOURCE` folder, including sub directories and files.",
+          "type": "string",
+          "const": "fs:scope-resource-recursive",
+          "markdownDescription": "This scope permits recursive access to the complete `$RESOURCE` folder, including sub directories and files."
+        },
+        {
+          "description": "This scope permits access to all files and list content of top level directories in the `$RUNTIME` folder.",
+          "type": "string",
+          "const": "fs:scope-runtime",
+          "markdownDescription": "This scope permits access to all files and list content of top level directories in the `$RUNTIME` folder."
+        },
+        {
+          "description": "This scope permits to list all files and folders in the `$RUNTIME`folder.",
+          "type": "string",
+          "const": "fs:scope-runtime-index",
+          "markdownDescription": "This scope permits to list all files and folders in the `$RUNTIME`folder."
+        },
+        {
+          "description": "This scope permits recursive access to the complete `$RUNTIME` folder, including sub directories and files.",
+          "type": "string",
+          "const": "fs:scope-runtime-recursive",
+          "markdownDescription": "This scope permits recursive access to the complete `$RUNTIME` folder, including sub directories and files."
+        },
+        {
+          "description": "This scope permits access to all files and list content of top level directories in the `$TEMP` folder.",
+          "type": "string",
+          "const": "fs:scope-temp",
+          "markdownDescription": "This scope permits access to all files and list content of top level directories in the `$TEMP` folder."
+        },
+        {
+          "description": "This scope permits to list all files and folders in the `$TEMP`folder.",
+          "type": "string",
+          "const": "fs:scope-temp-index",
+          "markdownDescription": "This scope permits to list all files and folders in the `$TEMP`folder."
+        },
+        {
+          "description": "This scope permits recursive access to the complete `$TEMP` folder, including sub directories and files.",
+          "type": "string",
+          "const": "fs:scope-temp-recursive",
+          "markdownDescription": "This scope permits recursive access to the complete `$TEMP` folder, including sub directories and files."
+        },
+        {
+          "description": "This scope permits access to all files and list content of top level directories in the `$TEMPLATE` folder.",
+          "type": "string",
+          "const": "fs:scope-template",
+          "markdownDescription": "This scope permits access to all files and list content of top level directories in the `$TEMPLATE` folder."
+        },
+        {
+          "description": "This scope permits to list all files and folders in the `$TEMPLATE`folder.",
+          "type": "string",
+          "const": "fs:scope-template-index",
+          "markdownDescription": "This scope permits to list all files and folders in the `$TEMPLATE`folder."
+        },
+        {
+          "description": "This scope permits recursive access to the complete `$TEMPLATE` folder, including sub directories and files.",
+          "type": "string",
+          "const": "fs:scope-template-recursive",
+          "markdownDescription": "This scope permits recursive access to the complete `$TEMPLATE` folder, including sub directories and files."
+        },
+        {
+          "description": "This scope permits access to all files and list content of top level directories in the `$VIDEO` folder.",
+          "type": "string",
+          "const": "fs:scope-video",
+          "markdownDescription": "This scope permits access to all files and list content of top level directories in the `$VIDEO` folder."
+        },
+        {
+          "description": "This scope permits to list all files and folders in the `$VIDEO`folder.",
+          "type": "string",
+          "const": "fs:scope-video-index",
+          "markdownDescription": "This scope permits to list all files and folders in the `$VIDEO`folder."
+        },
+        {
+          "description": "This scope permits recursive access to the complete `$VIDEO` folder, including sub directories and files.",
+          "type": "string",
+          "const": "fs:scope-video-recursive",
+          "markdownDescription": "This scope permits recursive access to the complete `$VIDEO` folder, including sub directories and files."
+        },
+        {
+          "description": "This enables all write related commands without any pre-configured accessible paths.",
+          "type": "string",
+          "const": "fs:write-all",
+          "markdownDescription": "This enables all write related commands without any pre-configured accessible paths."
+        },
+        {
+          "description": "This enables all file write related commands without any pre-configured accessible paths.",
+          "type": "string",
+          "const": "fs:write-files",
+          "markdownDescription": "This enables all file write related commands without any pre-configured accessible paths."
+        },
+        {
+          "description": "No features are enabled by default, as we believe\nthe shortcuts can be inherently dangerous and it is\napplication specific if specific shortcuts should be\nregistered or unregistered.\n",
+          "type": "string",
+          "const": "global-shortcut:default",
+          "markdownDescription": "No features are enabled by default, as we believe\nthe shortcuts can be inherently dangerous and it is\napplication specific if specific shortcuts should be\nregistered or unregistered.\n"
+        },
+        {
+          "description": "Enables the is_registered command without any pre-configured scope.",
+          "type": "string",
+          "const": "global-shortcut:allow-is-registered",
+          "markdownDescription": "Enables the is_registered command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the register command without any pre-configured scope.",
+          "type": "string",
+          "const": "global-shortcut:allow-register",
+          "markdownDescription": "Enables the register command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the register_all command without any pre-configured scope.",
+          "type": "string",
+          "const": "global-shortcut:allow-register-all",
+          "markdownDescription": "Enables the register_all command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the unregister command without any pre-configured scope.",
+          "type": "string",
+          "const": "global-shortcut:allow-unregister",
+          "markdownDescription": "Enables the unregister command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the unregister_all command without any pre-configured scope.",
+          "type": "string",
+          "const": "global-shortcut:allow-unregister-all",
+          "markdownDescription": "Enables the unregister_all command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the is_registered command without any pre-configured scope.",
+          "type": "string",
+          "const": "global-shortcut:deny-is-registered",
+          "markdownDescription": "Denies the is_registered command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the register command without any pre-configured scope.",
+          "type": "string",
+          "const": "global-shortcut:deny-register",
+          "markdownDescription": "Denies the register command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the register_all command without any pre-configured scope.",
+          "type": "string",
+          "const": "global-shortcut:deny-register-all",
+          "markdownDescription": "Denies the register_all command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the unregister command without any pre-configured scope.",
+          "type": "string",
+          "const": "global-shortcut:deny-unregister",
+          "markdownDescription": "Denies the unregister command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the unregister_all command without any pre-configured scope.",
+          "type": "string",
+          "const": "global-shortcut:deny-unregister-all",
+          "markdownDescription": "Denies the unregister_all command without any pre-configured scope."
+        },
+        {
+          "description": "This permission set configures which\nprocess features are by default exposed.\n\n#### Granted Permissions\n\nThis enables to quit via `allow-exit` and restart via `allow-restart`\nthe application.\n\n#### This default permission set includes:\n\n- `allow-exit`\n- `allow-restart`",
+          "type": "string",
+          "const": "process:default",
+          "markdownDescription": "This permission set configures which\nprocess features are by default exposed.\n\n#### Granted Permissions\n\nThis enables to quit via `allow-exit` and restart via `allow-restart`\nthe application.\n\n#### This default permission set includes:\n\n- `allow-exit`\n- `allow-restart`"
+        },
+        {
+          "description": "Enables the exit command without any pre-configured scope.",
+          "type": "string",
+          "const": "process:allow-exit",
+          "markdownDescription": "Enables the exit command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the restart command without any pre-configured scope.",
+          "type": "string",
+          "const": "process:allow-restart",
+          "markdownDescription": "Enables the restart command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the exit command without any pre-configured scope.",
+          "type": "string",
+          "const": "process:deny-exit",
+          "markdownDescription": "Denies the exit command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the restart command without any pre-configured scope.",
+          "type": "string",
+          "const": "process:deny-restart",
+          "markdownDescription": "Denies the restart command without any pre-configured scope."
+        },
+        {
+          "description": "This permission set configures which\nshell functionality is exposed by default.\n\n#### Granted Permissions\n\nIt allows to use the `open` functionality with a reasonable\nscope pre-configured. It will allow opening `http(s)://`,\n`tel:` and `mailto:` links.\n\n#### This default permission set includes:\n\n- `allow-open`",
+          "type": "string",
+          "const": "shell:default",
+          "markdownDescription": "This permission set configures which\nshell functionality is exposed by default.\n\n#### Granted Permissions\n\nIt allows to use the `open` functionality with a reasonable\nscope pre-configured. It will allow opening `http(s)://`,\n`tel:` and `mailto:` links.\n\n#### This default permission set includes:\n\n- `allow-open`"
+        },
+        {
+          "description": "Enables the execute command without any pre-configured scope.",
+          "type": "string",
+          "const": "shell:allow-execute",
+          "markdownDescription": "Enables the execute command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the kill command without any pre-configured scope.",
+          "type": "string",
+          "const": "shell:allow-kill",
+          "markdownDescription": "Enables the kill command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the open command without any pre-configured scope.",
+          "type": "string",
+          "const": "shell:allow-open",
+          "markdownDescription": "Enables the open command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the spawn command without any pre-configured scope.",
+          "type": "string",
+          "const": "shell:allow-spawn",
+          "markdownDescription": "Enables the spawn command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the stdin_write command without any pre-configured scope.",
+          "type": "string",
+          "const": "shell:allow-stdin-write",
+          "markdownDescription": "Enables the stdin_write command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the execute command without any pre-configured scope.",
+          "type": "string",
+          "const": "shell:deny-execute",
+          "markdownDescription": "Denies the execute command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the kill command without any pre-configured scope.",
+          "type": "string",
+          "const": "shell:deny-kill",
+          "markdownDescription": "Denies the kill command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the open command without any pre-configured scope.",
+          "type": "string",
+          "const": "shell:deny-open",
+          "markdownDescription": "Denies the open command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the spawn command without any pre-configured scope.",
+          "type": "string",
+          "const": "shell:deny-spawn",
+          "markdownDescription": "Denies the spawn command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the stdin_write command without any pre-configured scope.",
+          "type": "string",
+          "const": "shell:deny-stdin-write",
+          "markdownDescription": "Denies the stdin_write command without any pre-configured scope."
+        },
+        {
+          "description": "This permission set configures which kind of\nupdater functions are exposed to the frontend.\n\n#### Granted Permissions\n\nThe full workflow from checking for updates to installing them\nis enabled.\n\n\n#### This default permission set includes:\n\n- `allow-check`\n- `allow-download`\n- `allow-install`\n- `allow-download-and-install`",
+          "type": "string",
+          "const": "updater:default",
+          "markdownDescription": "This permission set configures which kind of\nupdater functions are exposed to the frontend.\n\n#### Granted Permissions\n\nThe full workflow from checking for updates to installing them\nis enabled.\n\n\n#### This default permission set includes:\n\n- `allow-check`\n- `allow-download`\n- `allow-install`\n- `allow-download-and-install`"
+        },
+        {
+          "description": "Enables the check command without any pre-configured scope.",
+          "type": "string",
+          "const": "updater:allow-check",
+          "markdownDescription": "Enables the check command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the download command without any pre-configured scope.",
+          "type": "string",
+          "const": "updater:allow-download",
+          "markdownDescription": "Enables the download command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the download_and_install command without any pre-configured scope.",
+          "type": "string",
+          "const": "updater:allow-download-and-install",
+          "markdownDescription": "Enables the download_and_install command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the install command without any pre-configured scope.",
+          "type": "string",
+          "const": "updater:allow-install",
+          "markdownDescription": "Enables the install command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the check command without any pre-configured scope.",
+          "type": "string",
+          "const": "updater:deny-check",
+          "markdownDescription": "Denies the check command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the download command without any pre-configured scope.",
+          "type": "string",
+          "const": "updater:deny-download",
+          "markdownDescription": "Denies the download command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the download_and_install command without any pre-configured scope.",
+          "type": "string",
+          "const": "updater:deny-download-and-install",
+          "markdownDescription": "Denies the download_and_install command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the install command without any pre-configured scope.",
+          "type": "string",
+          "const": "updater:deny-install",
+          "markdownDescription": "Denies the install command without any pre-configured scope."
+        }
+      ]
+    },
+    "Value": {
+      "description": "All supported ACL values.",
+      "anyOf": [
+        {
+          "description": "Represents a null JSON value.",
+          "type": "null"
+        },
+        {
+          "description": "Represents a [`bool`].",
+          "type": "boolean"
+        },
+        {
+          "description": "Represents a valid ACL [`Number`].",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Number"
+            }
+          ]
+        },
+        {
+          "description": "Represents a [`String`].",
+          "type": "string"
+        },
+        {
+          "description": "Represents a list of other [`Value`]s.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        },
+        {
+          "description": "Represents a map of [`String`] keys to [`Value`]s.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Value"
+          }
+        }
+      ]
+    },
+    "Number": {
+      "description": "A valid ACL number.",
+      "anyOf": [
+        {
+          "description": "Represents an [`i64`].",
+          "type": "integer",
+          "format": "int64"
+        },
+        {
+          "description": "Represents a [`f64`].",
+          "type": "number",
+          "format": "double"
+        }
+      ]
+    },
+    "Target": {
+      "description": "Platform target.",
+      "oneOf": [
+        {
+          "description": "MacOS.",
+          "type": "string",
+          "enum": [
+            "macOS"
+          ]
+        },
+        {
+          "description": "Windows.",
+          "type": "string",
+          "enum": [
+            "windows"
+          ]
+        },
+        {
+          "description": "Linux.",
+          "type": "string",
+          "enum": [
+            "linux"
+          ]
+        },
+        {
+          "description": "Android.",
+          "type": "string",
+          "enum": [
+            "android"
+          ]
+        },
+        {
+          "description": "iOS.",
+          "type": "string",
+          "enum": [
+            "iOS"
+          ]
+        }
+      ]
+    },
+    "ShellScopeEntryAllowedArg": {
+      "description": "A command argument allowed to be executed by the webview API.",
+      "anyOf": [
+        {
+          "description": "A non-configurable argument that is passed to the command in the order it was specified.",
+          "type": "string"
+        },
+        {
+          "description": "A variable that is set while calling the command from the webview API.",
+          "type": "object",
+          "required": [
+            "validator"
+          ],
+          "properties": {
+            "raw": {
+              "description": "Marks the validator as a raw regex, meaning the plugin should not make any modification at runtime.\n\nThis means the regex will not match on the entire string by default, which might be exploited if your regex allow unexpected input to be considered valid. When using this option, make sure your regex is correct.",
+              "default": false,
+              "type": "boolean"
+            },
+            "validator": {
+              "description": "[regex] validator to require passed values to conform to an expected input.\n\nThis will require the argument value passed to this variable to match the `validator` regex before it will be executed.\n\nThe regex string is by default surrounded by `^...$` to match the full string. For example the `https?://\\w+` regex would be registered as `^https?://\\w+$`.\n\n[regex]: <https://docs.rs/regex/latest/regex/#syntax>",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "ShellScopeEntryAllowedArgs": {
+      "description": "A set of command arguments allowed to be executed by the webview API.\n\nA value of `true` will allow any arguments to be passed to the command. `false` will disable all arguments. A list of [`ShellScopeEntryAllowedArg`] will set those arguments as the only valid arguments to be passed to the attached command configuration.",
+      "anyOf": [
+        {
+          "description": "Use a simple boolean to allow all or disable all arguments to this command configuration.",
+          "type": "boolean"
+        },
+        {
+          "description": "A specific set of [`ShellScopeEntryAllowedArg`] that are valid to call for the command configuration.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ShellScopeEntryAllowedArg"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/src-tauri/src/commands/patcher.rs
+++ b/src-tauri/src/commands/patcher.rs
@@ -127,6 +127,7 @@ pub fn start_patcher(
     result.into()
 }
 
+#[allow(unreachable_code, unused_variables)]
 pub(crate) fn start_patcher_inner(
     config: PatcherConfig,
     app_handle: &AppHandle,
@@ -134,11 +135,10 @@ pub(crate) fn start_patcher_inner(
     settings: &State<SettingsState>,
     library: &State<ModLibraryState>,
 ) -> AppResult<()> {
-    if cfg!(not(target_os = "windows")) {
-        return Err(AppError::Other(
-            "The patcher is not yet available on this platform".to_string(),
-        ));
-    }
+    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
+    return Err(AppError::Other(
+        "The patcher is not yet available on this platform".to_string(),
+    ));
 
     // Lock briefly: check state, set phase, clone what we need for the thread
     let (stop_flag, state_arc) = {

--- a/src-tauri/src/commands/platform.rs
+++ b/src-tauri/src/commands/platform.rs
@@ -16,7 +16,7 @@ pub struct PlatformSupport {
 pub fn get_platform_support() -> IpcResult<PlatformSupport> {
     IpcResult::ok(PlatformSupport {
         os: std::env::consts::OS.to_string(),
-        patcher_available: cfg!(target_os = "windows"),
+        patcher_available: cfg!(any(target_os = "windows", target_os = "macos")),
         hotkeys_available: cfg!(target_os = "windows"),
     })
 }

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -69,8 +69,8 @@ pub fn validate_league_path(path: PathBuf) -> IpcResult<bool> {
     let valid = if cfg!(target_os = "macos") {
         // Path points to the .app bundle (e.g. /Applications/League of Legends.app)
         path.join("Contents").join("LoL").join("Game").exists()
-            // Path points to the LoL root inside the bundle
-            || path.join("Game").join("League of Legends.app").exists()
+            // Path points to the LoL root inside the bundle (e.g. .../Contents/LoL)
+            || path.join("Game").join("LeagueofLegends.app").exists()
     } else {
         path.join("Game").join("League of Legends.exe").exists()
     };

--- a/src-tauri/src/legacy_patcher/api.rs
+++ b/src-tauri/src/legacy_patcher/api.rs
@@ -6,10 +6,15 @@ use libloading::Library;
 
 use crate::utils::native::{cstr_to_str, str_to_cstr_utf16};
 
-/// Bundled legacy patcher DLL (C implementation).
+/// Bundled patcher library name.
 ///
 /// This must match the relative path inside `src-tauri/resources/`.
+#[cfg(target_os = "windows")]
 pub const PATCHER_DLL_NAME: &str = "cslol-dll.dll";
+#[cfg(target_os = "macos")]
+pub const PATCHER_DLL_NAME: &str = "libcslol.dylib";
+#[cfg(not(any(target_os = "windows", target_os = "macos")))]
+pub const PATCHER_DLL_NAME: &str = "libcslol.so";
 
 #[repr(u64)]
 #[allow(dead_code)]

--- a/src/modules/patcher/components/PatcherUnsupported.tsx
+++ b/src/modules/patcher/components/PatcherUnsupported.tsx
@@ -9,7 +9,7 @@ export function PatcherUnsupported() {
           Patcher not available on this platform
         </span>
         <span className="text-xs text-surface-400">
-          Mod management works normally. The overlay patcher requires Windows.
+          Mod management works normally. The overlay patcher requires Windows or macOS.
         </span>
       </div>
     </div>


### PR DESCRIPTION
## What this does

Adds full macOS patcher support to ltk-manager. The patcher hooks into the running League of Legends process and redirects `.wad.client` file reads to load modded assets from the overlay directory, just like the Windows patcher does. The key difference is that the entire implementation is written from scratch because macOS and Vanguard impose constraints that make the Windows approach impossible.

The C++ patcher source lives in `src-tauri/cslol-dylib/` and exposes the same C API as the Windows `cslol-dll.dll` (`cslol_init`, `cslol_find`, `cslol_hook`, etc.), so the Rust side loads either library through `libloading` with zero platform branching. On macOS, `build.rs` invokes CMake to compile both arm64 and x86_64 targets, then `lipo` creates the universal binary. No prebuilt binaries are committed to the repository.

## The problem with macOS

Vanguard's macOS implementation monitors Mach IPC calls on the game's task port. When any external process calls `mach_vm_allocate` on League's task, Vanguard terminates the game within seconds. This means we cannot allocate new executable memory in the game process, which rules out the traditional approach of injecting a new code region.

However, `mach_vm_write` (writing to existing pages) still works because it's a Mach IPC operation that Vanguard doesn't block. Same for `mach_vm_protect` to change page permissions. This gives us a narrow but workable path: we can modify existing code and data in the game's address space, as long as we don't allocate anything new.

## How the patcher works

The patcher modifies two things in the running League process, all within existing memory pages:

### 1. wad_verify bypass and fopen hook

The game has a function called `wad_verify` that validates WAD file integrity. The patcher overwrites the first bytes of this function with a simple "return true" stub (8 bytes on arm64: `MOV X0, #1; RET`, 6 bytes on x86_64: `MOV EAX, 1; RET`).

The key insight is that `wad_verify` is a large function (272 bytes on arm64, 184 bytes on x86_64), and we only need 8 or 6 bytes for the bypass. The remaining space gets repurposed to hold a compact fopen hook. This hook is the core of the patching mechanism.

The game's `fopen` import stub (in the `__stubs` section) normally jumps through a GOT pointer to the real `fopen`. The patcher rewrites this stub to jump to our hook code instead. The hook checks every `fopen` call: if the filename ends with `.wad.client` and the mode is `"rb"`, it prepends the overlay directory path and tries opening the modded file first. If the modded file exists, it returns that handle. If not, it calls the original `fopen` through the saved GOT pointer, so the game loads the vanilla asset as normal.

The entire payload (bypass stub + hook code + data pointers) must fit inside `wad_verify`'s original code region. The final sizes are tight:
- arm64: 268 out of 272 bytes available (4 bytes margin)
- x86_64: 183 out of 184 bytes available (1 byte margin)

To make the arm64 payload fit, the strlen loop uses a `tbnz` instruction (test bit and branch if nonzero) instead of the usual `cmp` + `b.ge` pair, saving exactly 4 bytes needed for the overlay path pointer dereference.

### 2. Overlay path storage via __DATA segment gap

The hook needs to know where the overlay directory is on disk. Previous approaches used a `/tmp/c` symlink pointing to the overlay, with the symlink path hardcoded in the payload. This had problems: predictable path, race conditions, no cleanup guarantee.

Instead, the patcher writes the full overlay path directly into unused memory inside the game process. Specifically, it targets the gap at the end of the `__DATA` segment. This gap exists because the linker aligns the segment boundary to a page boundary (4KB), but the last data section rarely ends exactly at that boundary. The result is a region of mapped, writable, unused memory, typically 2KB+ on arm64 and 3KB+ on x86_64, more than enough for a path string.

The Mach-O parser (`macho.hpp`) calculates this gap by finding the `__DATA` segment, iterating its sections to find where the last one ends, and returning the address and size of the space between that point and the segment boundary. At patch time, the overlay path (with trailing `/`) is written there via `mach_vm_write`, and a pointer to that address is embedded in the payload blob.

No symlinks, no temporary files, no shared filesystem state. The data lives entirely in the target process's address space and gets cleaned up by the kernel when the game exits.

## Safety checks

Three layers of protection:

**Process verification**: before modifying anything, `patch_process()` reads the target process path via `proc_pidpath` and verifies it contains `LeagueofLegends`. This prevents accidentally patching the wrong process if the PID lookup returns something unexpected.

**Double-patch detection**: before writing the payload, the patcher reads the first bytes at the `wad_verify` offset in the target process and compares them against the bypass signature. If the bypass is already present, it means the process was already patched (e.g. from a previous session that didn't exit cleanly), and the patcher throws an error instead of corrupting the existing hook.

**Rust-side guards**: the existing `PatcherState` machinery prevents double-start (`is_running()` check), handles graceful shutdown via `AtomicBool` stop flag polled at multiple points, and `reject_if_patcher_running()` blocks mod install/uninstall/toggle/reorder operations while the patcher is active. All of this is shared with the Windows code path.

## What's not included

Entitlements and code signing. The app needs `com.apple.security.cs.debugger` (for `task_for_pid`) and `com.apple.security.cs.allow-unsigned-executable-memory` (for `mach_vm_protect` on executable pages) to function. But how to sign and distribute the app is a release pipeline decision that doesn't belong in this PR. Developers can ad-hoc sign locally for testing.

## Testing

Tested on Apple Silicon (arm64), macOS 26.4. The patcher finds the League process, applies the hook, and mods load correctly in game. After the game exits, the patcher returns to waiting and re-patches automatically on the next match. The stop button terminates cleanly. The x86_64 code path compiles and the payload fits within limits, but hasn't been tested on an Intel Mac.