### PR TITLE
feat(library): filter for enabled only

### DIFF
--- a/src/modules/library/api/useFilteredMods.ts
+++ b/src/modules/library/api/useFilteredMods.ts
@@ -5,7 +5,8 @@ import { sortMods } from "@/modules/library/utils";
 import { useLibraryFilterStore } from "@/stores";
 
 export function useFilteredMods(mods: InstalledMod[], searchQuery: string): InstalledMod[] {
-  const { selectedTags, selectedChampions, selectedMaps, sort } = useLibraryFilterStore();
+  const { selectedTags, selectedChampions, selectedMaps, showOnlyEnabled, sort } =
+    useLibraryFilterStore();
 
   return useMemo(() => {
     let result = mods;
@@ -15,6 +16,10 @@ export function useFilteredMods(mods: InstalledMod[], searchQuery: string): Inst
       result = result.filter(
         (mod) => mod.displayName.toLowerCase().includes(q) || mod.name.toLowerCase().includes(q),
       );
+    }
+
+    if (showOnlyEnabled) {
+      result = result.filter((mod) => mod.enabled);
     }
 
     if (selectedTags.size > 0) {
@@ -28,5 +33,5 @@ export function useFilteredMods(mods: InstalledMod[], searchQuery: string): Inst
     }
 
     return sortMods(result, sort);
-  }, [mods, searchQuery, selectedTags, selectedChampions, selectedMaps, sort]);
+  }, [mods, searchQuery, selectedTags, selectedChampions, selectedMaps, showOnlyEnabled, sort]);
 }

--- a/src/modules/library/components/FilterPopover.tsx
+++ b/src/modules/library/components/FilterPopover.tsx
@@ -36,6 +36,8 @@ export function FilterPopover({ filterOptions }: FilterPopoverProps) {
     toggleChampion,
     toggleMap,
     clearFilters,
+    showOnlyEnabled,
+    setShowOnlyEnabled,
   } = useLibraryFilterStore();
   const hasActive = useHasActiveFilters();
   const [champSearch, setChampSearch] = useState("");
@@ -94,6 +96,17 @@ export function FilterPopover({ filterOptions }: FilterPopoverProps) {
             </div>
 
             <div className="space-y-3">
+              <div className="flex flex-col gap-1.5 pb-1">
+                <Checkbox
+                  size="sm"
+                  label="Show only enabled"
+                  checked={showOnlyEnabled}
+                  onCheckedChange={setShowOnlyEnabled}
+                />
+              </div>
+
+              <Separator />
+
               <FilterSection title="Tags">
                 <div className="flex flex-wrap gap-1.5">
                   {tags.map((tag) => (

--- a/src/stores/libraryFilter.ts
+++ b/src/stores/libraryFilter.ts
@@ -12,6 +12,7 @@ interface LibraryFilterStore {
   selectedTags: Set<string>;
   selectedChampions: Set<string>;
   selectedMaps: Set<string>;
+  showOnlyEnabled: boolean;
   sort: SortConfig;
 
   toggleTag: (tag: string) => void;
@@ -21,6 +22,7 @@ interface LibraryFilterStore {
   setChampions: (champions: Set<string>) => void;
   setMaps: (maps: Set<string>) => void;
   clearFilters: () => void;
+  setShowOnlyEnabled: (show: boolean) => void;
   setSort: (sort: SortConfig) => void;
 }
 
@@ -28,6 +30,7 @@ export const useLibraryFilterStore = create<LibraryFilterStore>((set) => ({
   selectedTags: new Set(),
   selectedChampions: new Set(),
   selectedMaps: new Set(),
+  showOnlyEnabled: false,
   sort: { field: "priority", direction: "desc" },
 
   toggleTag: (tag) =>
@@ -63,13 +66,19 @@ export const useLibraryFilterStore = create<LibraryFilterStore>((set) => ({
       selectedTags: new Set(),
       selectedChampions: new Set(),
       selectedMaps: new Set(),
+      showOnlyEnabled: false,
     }),
 
+  setShowOnlyEnabled: (show) => set({ showOnlyEnabled: show }),
   setSort: (sort) => set({ sort }),
 }));
 
 export function useHasActiveFilters() {
   return useLibraryFilterStore(
-    (s) => s.selectedTags.size > 0 || s.selectedChampions.size > 0 || s.selectedMaps.size > 0,
+    (s) =>
+      s.selectedTags.size > 0 ||
+      s.selectedChampions.size > 0 ||
+      s.selectedMaps.size > 0 ||
+      s.showOnlyEnabled,
   );
 }


### PR DESCRIPTION
Feature: Creates a button in the top bar to allow users to quick filter "only enabled"

Preview without button disabled (not pressed):
<img width="1179" height="654" alt="image" src="https://github.com/user-attachments/assets/189db951-d3ee-4858-abe8-5229ad8cdd07" />

Preview with button enabled:
<img width="1193" height="539" alt="image" src="https://github.com/user-attachments/assets/b15cd142-7e02-432f-9a01-3db65710f38c" />



