### PR TITLE
fix(library): minor change UI bulk uninstall

### DIFF
--- a/src/modules/library/components/LibraryToolbar.tsx
+++ b/src/modules/library/components/LibraryToolbar.tsx
@@ -1,4 +1,4 @@
-import { CheckCheck, CheckSquare, Grid3X3, List, Play, Plus, Search, X } from "lucide-react";
+import { CheckCheck, Grid3X3, List, Play, Plus, Search, Trash2, X } from "lucide-react";
 
 import { Button, IconButton, Kbd, Tooltip } from "@/components";
 import type { InstalledMod, PatcherStatus } from "@/lib/tauri";
@@ -127,9 +127,10 @@ export function LibraryToolbar({
             size="sm"
             onClick={selectMode ? exitSelectMode : enterSelectMode}
             disabled={isPatcherActive || isLoading}
-            left={<CheckSquare className="h-4 w-4" />}
+            left={<Trash2 className="h-4 w-4" />}
+            className="min-w-[108px]"
           >
-            Select
+            {selectMode ? "Cancel" : "Uninstall"}
           </Button>
         </Tooltip>
 


### PR DESCRIPTION
Proposing a small UI change because the button said "Select" which is not intuitive or could be misleading.. **The main goal of the button/function is to uninstall** mods. _Not to Select._

[Before] Not clicked: Shows "Select"
<img width="230" height="82" alt="image" src="https://github.com/user-attachments/assets/50979957-243d-402b-bafd-e01c7ca5df4c" />

[Before] Clicked: Shows "Select"
<img width="216" height="113" alt="image" src="https://github.com/user-attachments/assets/f4d48ef6-138a-4102-958d-f5f713c23b3b" />



**Now with my proposal:**

[After] Not clicked: Shows "Uninstall"
<img width="458" height="154" alt="image" src="https://github.com/user-attachments/assets/c32973dc-3a47-45ff-9d33-f03e5cd38354" />

[After] Clicked: Shows "Cancel"
<img width="336" height="137" alt="image" src="https://github.com/user-attachments/assets/a0d3b3c6-10e1-460f-a614-a24907d006bc" />
