### PR TITLE
fix(library): prevent drag removal from folder with non-priority sort

### DIFF
--- a/src/modules/library/api/useUnifiedDnd.ts
+++ b/src/modules/library/api/useUnifiedDnd.ts
@@ -214,6 +214,7 @@ export function useUnifiedDnd({ folders, rootMods, modsByFolder, onReorder }: Us
           const mod = folderModLookup.get(c.id as string);
           return mod && mod.folderId === activeSourceFolderId;
         });
+        if (siblingsOnly.length === 0) return [];
         return closestCenter({ ...args, droppableContainers: siblingsOnly });
       }
 
@@ -238,7 +239,10 @@ export function useUnifiedDnd({ folders, rootMods, modsByFolder, onReorder }: Us
       );
       if (folderHit) return [folderHit];
 
-      const rootModsOnly = withoutFolderMods.filter((c) => !parseSortableFolderId(c.id as string));
+      const rootModsOnly = withoutFolderMods.filter(
+        (c) => !parseSortableFolderId(c.id as string) && c.id !== REMOVE_FROM_FOLDER_ID,
+      );
+      if (rootModsOnly.length === 0) return [];
       return closestCenter({ ...args, droppableContainers: rootModsOnly });
     },
     [folderModLookup, reorderDisabled],

--- a/src/modules/library/components/SortableModList.tsx
+++ b/src/modules/library/components/SortableModList.tsx
@@ -33,7 +33,10 @@ const removeZoneFirstCollision: CollisionDetection = (args) => {
   const pointerCollisions = pointerWithin(args);
   const removeHit = pointerCollisions.find((c) => c.id === REMOVE_FROM_FOLDER_ID);
   if (removeHit) return [removeHit];
-  return closestCenter(args);
+
+  const withoutRemoveZone = args.droppableContainers.filter((c) => c.id !== REMOVE_FROM_FOLDER_ID);
+  if (withoutRemoveZone.length === 0) return [];
+  return closestCenter({ ...args, droppableContainers: withoutRemoveZone });
 };
 
 interface SortableModListProps {


### PR DESCRIPTION
## Description

Fixes dragging a mod inside a folder incorrectly removing it when a non-priority sort (name, date) is active. The collision detection was passing the remove-from-folder droppable zone to `closestCenter`, causing false-positive hits.

Fixes #243

## Changes

- Filter out the `REMOVE_FROM_FOLDER_ID` droppable from root-level collision candidates in `useUnifiedDnd`
- Add early returns when filtered container lists are empty to prevent `closestCenter` from receiving zero candidates
- Exclude the remove zone from `closestCenter` fallback in `SortableModList`'s `removeZoneFirstCollision`

## Testing done

- [x] Manual testing — dragging mods within a folder no longer removes them when sort is set to name/date
- [x] Verified drag-to-remove still works when intentionally dragging to the remove zone

## Checklist

- [ ] Tests added / updated
- [x] No new warnings
- [x] Self-reviewed
