### PR TITLE
Add exit after successful patching setting

### DIFF
--- a/src-tauri/src/commands/patcher.rs
+++ b/src-tauri/src/commands/patcher.rs
@@ -352,6 +352,9 @@ pub(crate) fn start_patcher_inner(
         match Injector::new(injector_exe)
             .with_elevate(should_elevate)
             .on_event(move |event| match event {
+                InjectorEvent::Injected => {
+                    let _ = event_handle.emit("patcher-injected", ());
+                }
                 InjectorEvent::WadScanFailed { failures } => {
                     let payload = WadScanFailedPayload {
                         failures: failures

--- a/src-tauri/src/patcher/injector.rs
+++ b/src-tauri/src/patcher/injector.rs
@@ -29,6 +29,8 @@ pub enum InjectorError {
 /// command layer supplies a callback that translates these into UI events.
 #[derive(Debug, Clone)]
 pub enum InjectorEvent {
+    /// The host reported that the hook DLL attached to the game process.
+    Injected,
     /// One or more archives failed the injected DLL's integrity scan, so no mods
     /// were applied this session. The DLL aborts on the first failure, so we
     /// auto-stop the patcher and surface the failures instead of silently doing
@@ -250,6 +252,7 @@ impl Injector {
                         }
                         HostState::Injected => {
                             tracing::info!("[cslol-host] injected: {}", message);
+                            self.emit_event(InjectorEvent::Injected);
                         }
                         HostState::Waiting => {
                             tracing::info!("[cslol-host] waiting: {}", message);

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -207,6 +207,9 @@ pub struct Settings {
     /// Always start the patcher automatically on launch. Default: false.
     #[serde(default)]
     pub always_start_patcher: bool,
+    /// Exit the application after the patcher successfully injects into the game. Default: false.
+    #[serde(default)]
+    pub exit_after_patching: bool,
     /// Whether the user has dismissed the migration banner.
     #[serde(default)]
     pub migration_dismissed: bool,
@@ -286,6 +289,7 @@ impl Default for Settings {
             auto_run: false,
             start_in_tray_unless_update: false,
             always_start_patcher: false,
+            exit_after_patching: false,
             migration_dismissed: false,
             reload_mods_hotkey: None,
             kill_league_hotkey: None,
@@ -319,6 +323,7 @@ mod tests {
         assert_eq!(settings.theme, Theme::System);
         assert!(!settings.patch_tft);
         assert!(settings.minimize_to_tray);
+        assert!(!settings.exit_after_patching);
         assert!(!settings.migration_dismissed);
         assert!(settings.reload_mods_hotkey.is_none());
         assert!(settings.kill_league_hotkey.is_none());
@@ -351,6 +356,7 @@ mod tests {
             auto_run: false,
             start_in_tray_unless_update: false,
             always_start_patcher: false,
+            exit_after_patching: false,
             migration_dismissed: false,
             reload_mods_hotkey: Some("Ctrl+Shift+R".to_string()),
             kill_league_hotkey: None,

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,5 +1,6 @@
 export { useAutoStartPatcher } from "./useAutoStartPatcher";
 export { useClickOutside } from "./useClickOutside";
+export { useExitAfterPatching } from "./useExitAfterPatching";
 export { useHddWarning } from "./useHddWarning";
 export { usePlatformSupport } from "./usePlatformSupport";
 export { usePrevious } from "./usePrevious";

--- a/src/hooks/useExitAfterPatching.ts
+++ b/src/hooks/useExitAfterPatching.ts
@@ -1,0 +1,12 @@
+import { exit } from "@tauri-apps/plugin-process";
+
+import { useTauriEvent } from "@/lib/useTauriEvent";
+import { useSettings } from "@/modules/settings";
+
+export function useExitAfterPatching() {
+  const { data: settings } = useSettings();
+
+  useTauriEvent<void>(settings?.exitAfterPatching ? "patcher-injected" : null, () => {
+    void exit(0);
+  });
+}

--- a/src/lib/bindings/Settings.ts
+++ b/src/lib/bindings/Settings.ts
@@ -57,6 +57,10 @@ export type Settings = {
    */
   alwaysStartPatcher: boolean;
   /**
+   * Exit the application after the patcher successfully injects into the game. Default: false.
+   */
+  exitAfterPatching: boolean;
+  /**
    * Whether the user has dismissed the migration banner.
    */
   migrationDismissed: boolean;

--- a/src/modules/settings/components/PatchingSection.tsx
+++ b/src/modules/settings/components/PatchingSection.tsx
@@ -71,6 +71,21 @@ export function PatchingSection({ settings, onSave }: PatchingSectionProps) {
               off.
             </AlertBox>
           )}
+
+          <label className="flex items-center justify-between gap-4">
+            <div>
+              <span className="block text-sm font-medium text-surface-200">
+                Exit after patching
+              </span>
+              <span className="block text-sm text-surface-400">
+                Close LTK Manager after the patcher successfully injects into the running game.
+              </span>
+            </div>
+            <Switch
+              checked={settings.exitAfterPatching}
+              onCheckedChange={(checked) => onSave({ ...settings, exitAfterPatching: checked })}
+            />
+          </label>
         </div>
       </SectionCard>
 

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -4,7 +4,12 @@ import { Loader2 } from "lucide-react";
 import { useEffect } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 
-import { useAutoStartPatcher, useReducedMotion, useSurfaceLinkedBinWarning } from "@/hooks";
+import {
+  useAutoStartPatcher,
+  useExitAfterPatching,
+  useReducedMotion,
+  useSurfaceLinkedBinWarning,
+} from "@/hooks";
 import { ProtocolInstallDialog, useDeepLinkListener } from "@/modules/deep-link";
 import { useLibraryWatcher } from "@/modules/library";
 import { LinkedBinWarningDialog, PatcherStatusPill, WadScanFailedDialog } from "@/modules/patcher";
@@ -28,6 +33,7 @@ function RootLayout() {
   useDeepLinkListener();
   useLibraryWatcher();
   useAutoStartPatcher();
+  useExitAfterPatching();
   useSurfaceLinkedBinWarning();
 
   const update = useUpdaterUpdate();

--- a/src/test/fixtures.ts
+++ b/src/test/fixtures.ts
@@ -28,6 +28,7 @@ export function createMockSettings(overrides?: Partial<Settings>): Settings {
     autoRun: false,
     startInTrayUnlessUpdate: false,
     alwaysStartPatcher: false,
+    exitAfterPatching: false,
     hasSeenHddWarning: false,
     elevateInjector: false,
     autoCategorizationEnabled: true,


### PR DESCRIPTION
Adds a new toggle setting to the settings menu called 'Exit after patching'. My rationale for adding this setting was that LTK Manager and its subprocesses (Tauri/Edge WebView processes) were using upwards of 10%~ CPU usage on my system in the background for no reason at all considering that the program is no longer required after it patches the game (or at least until you decide to queue into a second game and need to patch it also). I tested the build and the setting works as expected for both states.
<img width="1920" height="519" alt="image" src="https://github.com/user-attachments/assets/9bff75b4-abb3-470d-be8f-1c454af88508" />
