### PR TITLE
fix(mods): accept numeric Fantome versions

### DIFF
--- a/crates/ltk-manager-core/src/mods/archive/metadata.rs
+++ b/crates/ltk-manager-core/src/mods/archive/metadata.rs
@@ -12,9 +12,11 @@ use crate::mods::index::LibraryModEntry;
 use crate::mods::types::{InstalledMod, ModLayer};
 use ltk_mod_project::{ModMap, ModProject, ModProjectLayer, ModTag};
 use ltk_modpkg::Modpkg;
+use regex::Regex;
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
 
 pub(crate) fn read_installed_mod(
     entry: &LibraryModEntry,
@@ -82,6 +84,36 @@ pub(crate) fn load_mod_project(mod_dir: &Path) -> AppResult<ModProject> {
     serde_json::from_str(&contents).map_err(AppError::from)
 }
 
+pub(crate) fn parse_fantome_info(
+    content: &str,
+) -> Result<ltk_fantome::FantomeInfo, serde_json::Error> {
+    static UNQUOTED_VERSION: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r#"("Version"\s*:\s*)([0-9]+(?:\.[0-9A-Za-z+-]+)+)"?(\s*[,}])"#)
+            .expect("unquoted Fantome version regex must be valid")
+    });
+
+    let normalized = UNQUOTED_VERSION.replace(content, r#"${1}"${2}"${3}"#);
+    let content = normalized.as_ref();
+
+    match serde_json::from_str(content) {
+        Ok(info) => Ok(info),
+        Err(original_error) => {
+            let Ok(mut value) = serde_json::from_str::<serde_json::Value>(content) else {
+                return Err(original_error);
+            };
+            let Some(version) = value.get_mut("Version") else {
+                return Err(original_error);
+            };
+            let serde_json::Value::Number(version_number) = version else {
+                return Err(original_error);
+            };
+
+            *version = serde_json::Value::String(version_number.to_string());
+            serde_json::from_value(value)
+        }
+    }
+}
+
 pub(crate) fn extract_fantome_metadata(file_path: &Path, metadata_dir: &Path) -> AppResult<()> {
     use std::io::Read;
     use zip::ZipArchive;
@@ -121,7 +153,7 @@ pub(crate) fn extract_fantome_metadata(file_path: &Path, metadata_dir: &Path) ->
 
     // Parse metadata
     let info_content = info_content.trim_start_matches('\u{feff}').trim();
-    let info: ltk_fantome::FantomeInfo = serde_json::from_str(info_content)
+    let info = parse_fantome_info(info_content)
         .map_err(|e| AppError::Other(format!("Failed to parse info.json: {}", e)))?;
 
     // Build layers from Fantome info, preserving string overrides
@@ -401,6 +433,40 @@ mod tests {
     fn load_mod_project_missing_file() {
         let dir = tempfile::tempdir().unwrap();
         assert!(load_mod_project(dir.path()).is_err());
+    }
+
+    #[test]
+    fn parse_fantome_info_accepts_unquoted_decimal_version() {
+        let content = r#"{
+            "Name": "Sausage dog Naafiri",
+            "Author": "Author",
+            "Version": 1.1,
+            "Description": "Description",
+            "Tags": [],
+            "Champions": [],
+            "Maps": [],
+            "Layers": {}
+        }"#;
+
+        let info = parse_fantome_info(content).unwrap();
+        assert_eq!(info.version, "1.1");
+    }
+
+    #[test]
+    fn parse_fantome_info_accepts_integer_version() {
+        let content = r#"{
+            "Name": "Test Mod",
+            "Author": "Author",
+            "Version": 2,
+            "Description": "Description",
+            "Tags": [],
+            "Champions": [],
+            "Maps": [],
+            "Layers": {}
+        }"#;
+
+        let info = parse_fantome_info(content).unwrap();
+        assert_eq!(info.version, "2");
     }
 
     #[test]

--- a/crates/ltk-manager-core/src/mods/archive/migration.rs
+++ b/crates/ltk-manager-core/src/mods/archive/migration.rs
@@ -182,7 +182,7 @@ fn read_cslol_info(path: &Path) -> AppResult<ltk_fantome::FantomeInfo> {
     let content = fs::read_to_string(path)?;
     let content = content.trim_start_matches('\u{feff}').trim();
 
-    serde_json::from_str(content).map_err(AppError::Serialization)
+    super::metadata::parse_fantome_info(content).map_err(AppError::Serialization)
 }
 
 #[cfg(test)]

--- a/crates/ltk-manager-core/src/mods/mod.rs
+++ b/crates/ltk-manager-core/src/mods/mod.rs
@@ -31,6 +31,7 @@ pub use analysis::categorize::{ChampionRoster, DerivedCategorization};
 pub use analysis::linked_bins::{LinkedBinOffenderInfo, LinkedBinState};
 pub use analysis::wad_reports::{ModWadReport, WadReportState};
 pub use archive::inspect::{ModpkgInfo, inspect_modpkg_file};
+pub(crate) use archive::metadata::parse_fantome_info;
 pub use archive::migration::*;
 pub use types::{BulkInstallResult, EditModMetadataArgs, InstalledMod, LibraryFolder, Profile};
 

--- a/crates/ltk-manager-core/src/workshop/projects.rs
+++ b/crates/ltk-manager-core/src/workshop/projects.rs
@@ -633,7 +633,7 @@ fn read_fantome_info<R: Read + Seek>(
     }
 
     let info_content = info_content.trim_start_matches('\u{feff}').trim();
-    serde_json::from_str(info_content)
+    crate::mods::parse_fantome_info(info_content)
         .map_err(|e| AppError::Fantome(format!("Failed to parse info.json: {}", e)))
 }
 


### PR DESCRIPTION
## What and why

Fantome metadata expects `Version` to be a string, but some existing mods use a numeric value such as `"Version": 1.1`.

This caused LTK Manager to reject the archive with:

> Failed to parse info.json: invalid type: floating point `1.1`, expected a string

A example is [Sausage dog Naafiri](https://runeforge.dev/mods/e1383e4e-67c3-47d1-8621-2a327e25d649), which could not be installed through the **Install with LTK Manager** flow.

This change:

- Accepts numeric and unquoted dotted Fantome version values.
- Converts those values to the string format expected by `ltk_fantome`.
- Uses the same parser for archive installation, cslol migration, and workshop peek/import flows.
- Preserves the original parse error for unrelated invalid metadata.

## How it was tested

- Added a regression test using the failing `"Version": 1.1` format.
- Added coverage for integer versions such as `"Version": 2`.
- Verified the RuneForge mod can proceed through the LTK Manager download/install flow.
- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- `cargo test` - 449 tests passed across 3 suites.

## Checklist

- [x] Title follows Conventional Commits (`feat:` / `fix:` / `docs:` / `chore:`; `!` for breaking)
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes
- [x] README / docs update not required; no public API or documented workflow changed
- [x] Tests added for the bug fixed or feature added