### PR TITLE
chore: release v1.15.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2915,7 +2915,7 @@ dependencies = [
 
 [[package]]
 name = "ltk-manager"
-version = "1.15.1"
+version = "1.15.2"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ltk-manager-ui",
   "private": true,
-  "version": "1.15.1",
+  "version": "1.15.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/third-party-licenses.json
+++ b/public/third-party-licenses.json
@@ -2114,7 +2114,7 @@
     },
     {
       "name": "ltk-manager",
-      "version": "1.15.1",
+      "version": "1.15.2",
       "url": "https://github.com/LeagueToolkit/ltk-manager",
       "licenses": [
         40

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ltk-manager"
-version = "1.15.1"
+version = "1.15.2"
 description = "LeagueToolkit Mod Manager - Desktop app for managing League of Legends mods"
 edition = "2021"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Bumps version to **v1.15.2** in `package.json` and `Cargo.toml`, and re-runs the licenses manifest. The meta schema snapshot is already current at build 8104348, so it is unchanged.

Built by hand because `release-prepare.yml` cannot reach `meta-api.leaguetoolkit.dev` from an Actions runner (403). Release notes are in `docs/releases/1.15.2.md`.